### PR TITLE
Add primary-site chart

### DIFF
--- a/charts/primary-site/.helmignore
+++ b/charts/primary-site/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: primary-site
+description: Foxglove Primary Site
+icon: https://foxglove.dev/images/logo-icon-round.png
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+#
+# Example versions:
+# 1.0.0-alpha.0
+# 1.0.0-alpha.1
+# 1.0.0
+version: 0.0.0-alpha.1
+
+appVersion: "0.0.0"

--- a/charts/primary-site/templates/NOTES.txt
+++ b/charts/primary-site/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Welcome to your Foxglove Primary Site!
+
+See the status of your release:
+
+    helm status -n foxglove foxglove-primary-site
+
+Complete your site installation:
+
+    https://foxglove.dev/docs/data-platform/primary-sites/installation
+
+Import data to your new site:
+
+    https://foxglove.dev/docs/data-platform/primary-sites/manage-data

--- a/charts/primary-site/templates/secret.yaml
+++ b/charts/primary-site/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foxglove-site
+type: Opaque
+data:
+  token: "{{ required "A valid site_token is required!" .Values.globals.site_token | b64enc }}"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,0 +1,3 @@
+globals:
+  site_token:
+  foxglove_api_url: https://api.foxglove.dev


### PR DESCRIPTION
Add a mostly empty chart for primary-site. We'll populate this chart in follow-up work items (ticketed in linear) as the various components become testable.