### PR TITLE
Release edge-site 0.0.1

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.0-alpha.11
+version: "0.0.1"
 
 appVersion: "0.0.0"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
             optional: true
       containers:
         - name: edge-controller
-          image: us-central1-docker.pkg.dev/foxglove-images/images/edge-controller:61c70bcdefc6cb76fcb789293d7548527b6b3fce
+          image: us-central1-docker.pkg.dev/foxglove-images/images/edge-controller:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
           volumeMounts:
             - mountPath: /data/storage
               name: storage-root


### PR DESCRIPTION
**Public-Facing Changes**

This updates the edge controller to https://github.com/foxglove/data-platform/commit/dcb5b4812e4d0a6054638ea43712f2e7ee5050ab, which reads retention period configuration from the control plane.

The version is bumped to 0.0.1, no longer alpha.
