### PR TITLE
Primary sites helm chart with inbox-processor deployment

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.0-alpha.1
+version: 0.0.0-alpha.2
 
 appVersion: "0.0.0"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: 0.0.0-alpha.2
 
-appVersion: "0.0.0"
+appVersion: "db6c30de466b6cd704de25c9ffea63195b4aa0f3"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -32,7 +32,7 @@ spec:
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: /secrets/credential.json
                 - name: FOXGLOVE_API_URL
-                  value: "{{ .Values.globals.foxglove_api_url }}"
+                  value: "{{ .Values.globals.foxgloveApiUrl }}"
                 - name: FOXGLOVE_SITE_TOKEN
                   valueFrom:
                     secretKeyRef:
@@ -42,6 +42,10 @@ spec:
                 - name: MODE
                   value: self-managed
                 - name: STORAGE_PROVIDER
-                  value: "{{ .Values.primary_site.lakeStorageProvider }}"
+                  value: "{{ .Values.primarySite.lake.storageProvider }}"
+                - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
+                  value: "{{ .Values.primarySite.azure.storageAccountName }}"
+                - name: STORAGE_AZURE_SERVICE_URL
+                  value: "{{ .Values.primarySite.azure.serviceUrl }}"
           serviceAccountName: garbage-collector
           restartPolicy: OnFailure

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -6,7 +6,7 @@ metadata:
     app: garbage-collector
 spec:
   concurrencyPolicy: Forbid
-  schedule: {{ .Values.garbageCollector.schedule }}
+  schedule: "{{ .Values.garbageCollector.schedule }}"
   failedJobsHistoryLimit: {{ .Values.garbageCollector.failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.garbageCollector.successfulJobsHistoryLimit }}
   jobTemplate:
@@ -20,7 +20,7 @@ spec:
                 optional: true
           containers:
             - name: garbage-collector
-              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:{{ .Values.globals.imageTag }}
+              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:{{ .Chart.AppVersion }}
               volumeMounts:
                 - mountPath: /secrets
                   name: cloud-credentials

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: garbage-collector
   labels:
-    app: foxglove-garbage-collector
+    app: garbage-collector
 spec:
   schedule: "*/10 * * * *" # every 10 minutes
   concurrencyPolicy: Forbid
@@ -20,7 +20,7 @@ spec:
                 optional: true
           containers:
             - name: garbage-collector
-              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:{{ .Values.globals.imageTag }}
               volumeMounts:
                 - mountPath: /secrets
                   name: cloud-credentials
@@ -42,10 +42,9 @@ spec:
                 - name: MODE
                   value: self-managed
                 - name: STORAGE_PROVIDER
-                  value: "{{ .Values.primarySite.lake.storageProvider }}"
+                  value: "{{ .Values.globals.lake.storageProvider }}"
                 - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
-                  value: "{{ .Values.primarySite.azure.storageAccountName }}"
+                  value: "{{ .Values.globals.azure.storageAccountName }}"
                 - name: STORAGE_AZURE_SERVICE_URL
-                  value: "{{ .Values.primarySite.azure.serviceUrl }}"
-          serviceAccountName: garbage-collector
+                  value: "{{ .Values.globals.azure.serviceUrl }}"
           restartPolicy: OnFailure

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: garbage-collector
+  labels:
+    app: foxglove-garbage-collector
+spec:
+  schedule: "*/10 * * * *" # every 10 minutes
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: cloud-credentials
+              secret:
+                secretName: gcp-cloud-credential
+                optional: true
+          containers:
+            - name: garbage-collector
+              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+              volumeMounts:
+                - mountPath: /secrets
+                  name: cloud-credentials
+              envFrom:
+                - secretRef:
+                    name: cloud-credentials
+                    optional: true
+              env:
+                - name: GOOGLE_APPLICATION_CREDENTIALS
+                  value: /secrets/credential.json
+                - name: FOXGLOVE_API_URL
+                  value: "{{ .Values.globals.foxglove_api_url }}"
+                - name: FOXGLOVE_SITE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: foxglove-site
+                      key: token
+                      optional: false
+                - name: MODE
+                  value: self-managed
+                - name: STORAGE_PROVIDER
+                  value: "{{ .Values.primary_site.lakeStorageProvider }}"
+          serviceAccountName: garbage-collector
+          restartPolicy: OnFailure

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     app: garbage-collector
 spec:
-  schedule: "*/10 * * * *" # every 10 minutes
   concurrencyPolicy: Forbid
-  failedJobsHistoryLimit: 1
-  successfulJobsHistoryLimit: 3
+  schedule: {{ .Values.garbageCollector.schedule }}
+  failedJobsHistoryLimit: {{ .Values.garbageCollector.failedJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.garbageCollector.successfulJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -28,11 +28,11 @@ spec:
           image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:{{ .Values.globals.imageTag }}
           resources:
             requests:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: {{ .Values.inboxListener.deployment.resources.requests.cpu }}
+              memory: {{ .Values.inboxListener.deployment.resources.requests.memory }}
             limits:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: {{ .Values.inboxListener.deployment.resources.limits.cpu }}
+              memory: {{ .Values.inboxListener.deployment.resources.limits.memory }}
           volumeMounts:
             - mountPath: /secrets
               name: cloud-credentials

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inbox-listener
+  labels:
+    app: foxglove-inbox-listener
+spec:
+  selector:
+    matchLabels:
+      app: foxglove-inbox-listener
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: foxglove-inbox-listener
+    spec:
+      containers:
+        - name: inbox-listener
+          image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          envFrom:
+            - secretRef:
+                name: cloud-credentials
+                optional: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/credential.json
+            - name: FOXGLOVE_API_URL
+              value: "{{ .Values.globals.foxglove_api_url }}"
+            - name: FOXGLOVE_SITE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: foxglove-site
+                  key: token
+                  optional: false
+            - name: MODE
+              value: self-managed
+            - name: INBOX_STORAGE_PROVIDER
+              value: "{{ .Values.primary_site.inboxStorageProvider }}"
+            - name: LAKE_STORAGE_PROVIDER
+              value: "{{ .Values.primary_site.lakeStorageProvider }}"
+            - name: STORAGE_LAKE_BUCKET_NAME
+              value: "{{ .Values.primary_site.lakeBucketName }}"
+      serviceAccountName: inbox-listener

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -25,7 +25,7 @@ spec:
             optional: true
       containers:
         - name: inbox-listener
-          image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:{{ .Values.globals.imageTag }}
+          image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.inboxListener.deployment.resources.requests.cpu }}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -44,7 +44,7 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credential.json
             - name: FOXGLOVE_API_URL
-              value: "{{ .Values.globals.foxglove_api_url }}"
+              value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: FOXGLOVE_SITE_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -54,9 +54,13 @@ spec:
             - name: MODE
               value: self-managed
             - name: INBOX_STORAGE_PROVIDER
-              value: "{{ .Values.primary_site.inboxStorageProvider }}"
+              value: "{{ .Values.primarySite.inbox.storageProvider }}"
             - name: LAKE_STORAGE_PROVIDER
-              value: "{{ .Values.primary_site.lakeStorageProvider }}"
+              value: "{{ .Values.primarySite.lake.storageProvider }}"
             - name: STORAGE_LAKE_BUCKET_NAME
-              value: "{{ .Values.primary_site.lakeBucketName }}"
+              value: "{{ .Values.primarySite.lake.bucketName }}"
+            - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
+              value: "{{ .Values.primarySite.azure.storageAccountName }}"
+            - name: STORAGE_AZURE_SERVICE_URL
+              value: "{{ .Values.primarySite.azure.serviceUrl }}"
       serviceAccountName: inbox-listener

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         app: foxglove-inbox-listener
     spec:
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: gcp-cloud-credential
+            optional: true
       containers:
         - name: inbox-listener
           image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
@@ -28,6 +33,9 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          volumeMounts:
+            - mountPath: /secrets
+              name: cloud-credentials
           envFrom:
             - secretRef:
                 name: cloud-credentials

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -3,11 +3,11 @@ kind: Deployment
 metadata:
   name: inbox-listener
   labels:
-    app: foxglove-inbox-listener
+    app: inbox-listener
 spec:
   selector:
     matchLabels:
-      app: foxglove-inbox-listener
+      app: inbox-listener
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        app: foxglove-inbox-listener
+        app: inbox-listener
     spec:
       volumes:
         - name: cloud-credentials
@@ -25,7 +25,7 @@ spec:
             optional: true
       containers:
         - name: inbox-listener
-          image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+          image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:{{ .Values.globals.imageTag }}
           resources:
             requests:
               cpu: 1000m
@@ -54,13 +54,12 @@ spec:
             - name: MODE
               value: self-managed
             - name: INBOX_STORAGE_PROVIDER
-              value: "{{ .Values.primarySite.inbox.storageProvider }}"
+              value: "{{ .Values.globals.inbox.storageProvider }}"
             - name: LAKE_STORAGE_PROVIDER
-              value: "{{ .Values.primarySite.lake.storageProvider }}"
+              value: "{{ .Values.globals.lake.storageProvider }}"
             - name: STORAGE_LAKE_BUCKET_NAME
-              value: "{{ .Values.primarySite.lake.bucketName }}"
+              value: "{{ .Values.globals.lake.bucketName }}"
             - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
-              value: "{{ .Values.primarySite.azure.storageAccountName }}"
+              value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
-              value: "{{ .Values.primarySite.azure.serviceUrl }}"
-      serviceAccountName: inbox-listener
+              value: "{{ .Values.globals.azure.serviceUrl }}"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -29,11 +29,11 @@ spec:
           image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:{{ .Values.globals.imageTag }}
           resources:
             requests:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}
+              memory: {{ .Values.streamService.deployment.resources.requests.memory }}
             limits:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: {{ .Values.streamService.deployment.resources.limits.cpu }}
+              memory: {{ .Values.streamService.deployment.resources.limits.memory }}
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -26,7 +26,7 @@ spec:
             optional: true
       containers:
         - name: stream-service
-          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:{{ .Values.globals.imageTag }}
+          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stream-service
+  labels:
+    app: foxglove-stream-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foxglove-stream-service
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: foxglove-stream-service
+    spec:
+      volumes:
+        - name: cloud-credentials
+          secret:
+            secretName: gcp-cloud-credential
+            optional: true
+      containers:
+        - name: stream-service
+          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: /secrets
+              name: cloud-credentials
+          envFrom:
+            - secretRef:
+                name: cloud-credentials
+                optional: true
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/credential.json
+            - name: FOXGLOVE_API_URL
+              value: "{{ .Values.globals.foxglove_api_url }}"
+            - name: PORT
+              value: "8080"
+            - name: STORAGE_PROVIDER
+              value: "{{ .Values.primary_site.lakeStorageProvider }}"
+      serviceAccountName: stream-service
+      terminationGracePeriodSeconds: 30

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -47,10 +47,14 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credential.json
             - name: FOXGLOVE_API_URL
-              value: "{{ .Values.globals.foxglove_api_url }}"
+              value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: PORT
               value: "8080"
             - name: STORAGE_PROVIDER
-              value: "{{ .Values.primary_site.lakeStorageProvider }}"
+              value: "{{ .Values.primarySite.lake.storageProvider }}"
+            - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
+              value: "{{ .Values.primarySite.azure.storageAccountName }}"
+            - name: STORAGE_AZURE_SERVICE_URL
+              value: "{{ .Values.primarySite.azure.serviceUrl }}"
       serviceAccountName: stream-service
       terminationGracePeriodSeconds: 30

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -3,12 +3,12 @@ kind: Deployment
 metadata:
   name: stream-service
   labels:
-    app: foxglove-stream-service
+    app: stream-service
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: foxglove-stream-service
+      app: stream-service
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       labels:
-        app: foxglove-stream-service
+        app: stream-service
     spec:
       volumes:
         - name: cloud-credentials
@@ -26,7 +26,7 @@ spec:
             optional: true
       containers:
         - name: stream-service
-          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:{{ .Values.globals.imageTag }}
           resources:
             requests:
               cpu: 1000m
@@ -51,10 +51,9 @@ spec:
             - name: PORT
               value: "8080"
             - name: STORAGE_PROVIDER
-              value: "{{ .Values.primarySite.lake.storageProvider }}"
+              value: "{{ .Values.globals.lake.storageProvider }}"
             - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
-              value: "{{ .Values.primarySite.azure.storageAccountName }}"
+              value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
-              value: "{{ .Values.primarySite.azure.serviceUrl }}"
-      serviceAccountName: stream-service
+              value: "{{ .Values.globals.azure.serviceUrl }}"
       terminationGracePeriodSeconds: 30

--- a/charts/primary-site/templates/secret.yaml
+++ b/charts/primary-site/templates/secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: foxglove-site
 type: Opaque
 data:
-  token: "{{ required "A valid site_token is required!" .Values.globals.site_token | b64enc }}"
+  token: {{ required "A valid site_token is required!" .Values.globals.site_token | b64enc }}

--- a/charts/primary-site/templates/secret.yaml
+++ b/charts/primary-site/templates/secret.yaml
@@ -4,4 +4,4 @@ metadata:
   name: foxglove-site
 type: Opaque
 data:
-  token: {{ required "A valid site_token is required!" .Values.globals.site_token | b64enc }}
+  token: {{ required "A valid site_token is required!" .Values.globals.siteToken | b64enc }}

--- a/charts/primary-site/templates/serviceaccount/inbox-listener.yaml
+++ b/charts/primary-site/templates/serviceaccount/inbox-listener.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inbox-listener
+  annotations:
+    {{- range $key, $value := .Values.primary_site.serviceAccountAnnotations.inboxListener }}
+      {{ $key }}: {{ $value }}
+    {{- end }}

--- a/charts/primary-site/templates/serviceaccount/inbox-listener.yaml
+++ b/charts/primary-site/templates/serviceaccount/inbox-listener.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: inbox-listener
-  annotations:
-    {{- range $key, $value := .Values.primary_site.serviceAccountAnnotations.inboxListener }}
-      {{ $key }}: {{ $value }}
-    {{- end }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,3 +1,12 @@
 globals:
   site_token:
   foxglove_api_url: https://api.foxglove.dev
+
+primary_site:
+  lakeStorageProvider: google_cloud
+  inboxStorageProvider: google_cloud
+  lakeBucketName: foxglove-lake
+
+  serviceAccountAnnotations:
+    inboxListener:
+      iam.gke.io/gcp-service-account: inbox-listener@example-project-id.iam.gserviceaccount.com

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,16 +1,18 @@
 globals:
   siteToken:
   foxgloveApiUrl: https://api.foxglove.dev
+  imageTag: db6c30de466b6cd704de25c9ffea63195b4aa0f3
 
-primarySite:
+  ## Supported storageProvider values are: `google_cloud` or `azure`
+  ## If `azure` is used, then the `@azure.storageAccountName` and `@azure.serviceUrl` values
+  ## are required.
   lake:
-    # Acceptable storageProvider values are: `google_cloud` or `azure`;
-    # If `azure is used`, the `azure.storageAccountName` and `azure.serviceUrl` are required.
     storageProvider: google_cloud
     bucketName: foxglove-lake
   inbox:
     storageProvider: google_cloud
 
   azure:
-    storageAccountName:
-    serviceUrl:
+    storageAccountName: ""
+    ## For example: https://<resourcegroup>.blob.core.windows.net
+    serviceUrl: ""

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,8 +1,16 @@
 globals:
-  site_token:
-  foxglove_api_url: https://api.foxglove.dev
+  siteToken:
+  foxgloveApiUrl: https://api.foxglove.dev
 
-primary_site:
-  lakeStorageProvider: google_cloud
-  inboxStorageProvider: google_cloud
-  lakeBucketName: foxglove-lake
+primarySite:
+  lake:
+    # Acceptable storageProvider values are: `google_cloud` or `azure`;
+    # If `azure is used`, the `azure.storageAccountName` and `azure.serviceUrl` are required.
+    storageProvider: google_cloud
+    bucketName: foxglove-lake
+  inbox:
+    storageProvider: google_cloud
+
+  azure:
+    storageAccountName:
+    serviceUrl:

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -6,7 +6,3 @@ primary_site:
   lakeStorageProvider: google_cloud
   inboxStorageProvider: google_cloud
   lakeBucketName: foxglove-lake
-
-  serviceAccountAnnotations:
-    inboxListener:
-      iam.gke.io/gcp-service-account: inbox-listener@example-project-id.iam.gserviceaccount.com

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,7 +1,6 @@
 globals:
   siteToken:
   foxgloveApiUrl: https://api.foxglove.dev
-  imageTag: db6c30de466b6cd704de25c9ffea63195b4aa0f3
 
   ## Supported storageProvider values are: `google_cloud` or `azure`
   ## If `azure` is used, then the `@azure.storageAccountName` and `@azure.serviceUrl` values

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -16,3 +16,28 @@ globals:
     storageAccountName: ""
     ## For example: https://<resourcegroup>.blob.core.windows.net
     serviceUrl: ""
+
+inboxListener:
+  deployment:
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1Gi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+
+streamService:
+  deployment:
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1Gi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+
+garbageCollector:
+  schedule: "*/10 * * * *" # every 10 minutes
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3


### PR DESCRIPTION
Notes / to discuss:

- [x] All pubsub-related configuration can be removed, because self-managed sites (see `MODE=self-managed`) will use Console — but if we do so, the inbox-processor will fail on the `PUBSUB_INBOX_SUBSCRIPTION` env var missing at startup time.

(Solved, needed a more up to date container)

- [x] Using different storage providers might require the presence of different env variables for some of the services. One example: on Azure, stream-service needs to have `STORAGE_AZURE_STORAGE_ACCOUNT_NAME` set.

(Solved, configurable through `azure:` ...)

Docs PR: https://github.com/foxglove/website/pull/916