### PR TITLE
Define names for exposed edge-site services

### DIFF
--- a/charts/edge-site/templates/service.yaml
+++ b/charts/edge-site/templates/service.yaml
@@ -6,9 +6,11 @@ spec:
   selector:
     app: foxglove-edge-site
   ports:
-    - protocol: TCP
+    - name: controller
+      protocol: TCP
       port: 8888
       targetPort: 9099
-    - protocol: TCP
+    - name: metrics
+      protocol: TCP
       port: 6002
       targetPort: 6002


### PR DESCRIPTION
Name is required once multiple services are defined.