### PR TITLE
Update to latest version

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.0-alpha.2
+version: 0.0.0-alpha.3
 
-appVersion: "db6c30de466b6cd704de25c9ffea63195b4aa0f3"
+appVersion: "e2eb36b52e0231841832f688fb4296fe92a9ef8e"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -56,4 +56,16 @@ spec:
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
               value: "{{ .Values.globals.azure.serviceUrl }}"
+          readinessProbe:
+            httpGet:
+              path: /liveness
+              port: 8080
+            periodSeconds: 3
+            timeoutSeconds: 1
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8080
+            periodSeconds: 3
+            timeoutSeconds: 1
       terminationGracePeriodSeconds: 30

--- a/charts/primary-site/templates/services/stream.yaml
+++ b/charts/primary-site/templates/services/stream.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stream
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+  selector:
+    app: stream-service


### PR DESCRIPTION
Add stream service.

Add liveness and readiness probes to stream service deployment to simplify ingress setup. The GKE ingress looks for a readinessProbe and makes that the backend config readiness check during setup.