### PR TITLE
AWS-specific config & env variables

### DIFF
--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -53,3 +53,19 @@ spec:
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
+            - name: AWS_REGION
+              value: "{{ .Values.globals.aws.region }}"
+            - name: AWS_SDK_LOAD_CONFIG
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_ACCESS_KEY_ID
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+                  optional: true

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -4,6 +4,10 @@ globals:
   siteToken:
   foxgloveApiUrl: https://api.foxglove.dev
 
+  aws:
+    ## For example: us-east-1
+    region: ""
+
 edgeController:
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: 0.0.0-alpha.4
 
-appVersion: "fb44ce1db840bafe3e907e6d8210c4e5aedfccad"
+appVersion: "d675938fc6a7a0a74d0e21df2c748447bb7b617f"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -47,4 +47,20 @@ spec:
                   value: "{{ .Values.globals.azure.storageAccountName }}"
                 - name: STORAGE_AZURE_SERVICE_URL
                   value: "{{ .Values.globals.azure.serviceUrl }}"
+                - name: AWS_REGION
+                  value: "{{ .Values.globals.aws.region }}"
+                - name: AWS_SDK_LOAD_CONFIG
+                  value: "true"
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: cloud-credentials
+                      key: AWS_ACCESS_KEY_ID
+                      optional: true
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cloud-credentials
+                      key: AWS_SECRET_ACCESS_KEY
+                      optional: true
           restartPolicy: OnFailure

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -65,3 +65,19 @@ spec:
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
               value: "{{ .Values.globals.azure.serviceUrl }}"
+            - name: AWS_REGION
+              value: "{{ .Values.globals.aws.region }}"
+            - name: AWS_SDK_LOAD_CONFIG
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_ACCESS_KEY_ID
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+                  optional: true

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -56,6 +56,22 @@ spec:
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
               value: "{{ .Values.globals.azure.serviceUrl }}"
+            - name: AWS_REGION
+              value: "{{ .Values.globals.aws.region }}"
+            - name: AWS_SDK_LOAD_CONFIG
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_ACCESS_KEY_ID
+                  optional: true
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+                  optional: true
           readinessProbe:
             httpGet:
               path: /liveness

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -2,9 +2,9 @@ globals:
   siteToken:
   foxgloveApiUrl: https://api.foxglove.dev
 
-  ## Supported storageProvider values are: `google_cloud` or `azure`
+  ## Supported storageProvider values are: `google_cloud`, `aws` or `azure`
   ## If `azure` is used, then the `@azure.storageAccountName` and `@azure.serviceUrl` values
-  ## are required.
+  ## are required. If `aws` is used, then the `@aws.region` value is required.
   lake:
     storageProvider: google_cloud
     bucketName: foxglove-lake
@@ -16,6 +16,10 @@ globals:
     storageAccountName: ""
     ## For example: https://<resourcegroup>.blob.core.windows.net
     serviceUrl: ""
+
+  aws:
+    ## For example: us-east-1
+    region: ""
 
 inboxListener:
   deployment:


### PR DESCRIPTION
**Public-Facing Changes**

The AWS credentials are already added to the secret as described in [the docs](https://foxglove.dev/docs/data-platform/primary-sites/configure-cloud-credentials), but the services need these to be configured in env variables as well (otherwise the go aws package won't be able to read/write the buckets).

(Note another alternative could be to create and use an `~./aws/credentials` file, which will make the setup more similar to the GCP part of the charts.)