### PR TITLE
Add upload provider and bucket name as required helm values

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: "0.0.3"
 
-appVersion: "0.0.0"
+appVersion: "e29ff09f68025bf55fa84718dea6842517a8507a"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
             optional: true
       containers:
         - name: edge-controller
-          image: us-central1-docker.pkg.dev/foxglove-images/images/edge-controller:dcb5b4812e4d0a6054638ea43712f2e7ee5050ab
+          image: us-central1-docker.pkg.dev/foxglove-images/images/edge-controller:{{ .Chart.AppVersion }}
           volumeMounts:
             - mountPath: /data/storage
               name: storage-root

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -57,3 +57,7 @@ spec:
               value: "true"
             - name: AWS_REGION
               value: "{{ .Values.globals.aws.region }}"
+            - name: INBOX_STORAGE_PROVIDER
+              value: "{{ .Values.globals.upload.provider }}"
+            - name: INBOX_BUCKET_NAME
+              value: "{{ .Values.globals.upload.bucketName }}"

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -1,12 +1,23 @@
 # Default values for edge-site.
 
 globals:
+  # The site token provides authentication to the foxglove api for the deployment
   siteToken:
+
+  # The api endpoint the deployment will use as the control plane
   foxgloveApiUrl: https://api.foxglove.dev
 
   aws:
     ## For example: us-east-1
     region: ""
+
+  # This section configures where the deployment will upload files you wish to import into a primary site
+  upload:
+    # The cloud provider where the destination inbox bucket lives
+    # Values values: aws, azure, google_cloud
+    provider:
+    # The bucket name where the deployment will send
+    bucketName:
 
 edgeController:
   storageClaim: edge-controller-storage-claim

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -16,7 +16,7 @@ globals:
     # The cloud provider where the destination inbox bucket lives
     # Values values: aws, azure, google_cloud
     provider:
-    # The bucket name where the deployment will send
+    # The bucket name where the deployment will send the requested files
     bucketName:
 
 edgeController:


### PR DESCRIPTION
The provider and bucket name are now required configuration values for edge sites. Rather than require the user to configure this information in the UI we require this configuration in the values when the deployment is setup. The user must specify this information when deploying their edge site.

Related data platform change: https://github.com/foxglove/data-platform/pull/808/