### PR TITLE
Enable configuration of static replica count

### DIFF
--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: inbox-listener
 spec:
+  replicas: {{ .Values.inboxListener.deployment.replicas }}
   selector:
     matchLabels:
       app: inbox-listener

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: stream-service
 spec:
-  replicas: 1
+  replicas: {{ .Values.streamService.deployment.replicas }}
   selector:
     matchLabels:
       app: stream-service

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -23,6 +23,7 @@ globals:
 
 inboxListener:
   deployment:
+    replicas: 1
     resources:
       requests:
         cpu: 1000m
@@ -33,6 +34,7 @@ inboxListener:
 
 streamService:
   deployment:
+    replicas: 1
     resources:
       requests:
         cpu: 1000m


### PR DESCRIPTION
Enables configuration of a static replica count, defaulted to 1 for the stream service and inbox listener. When HPA support is enabled, we will guard this behind an hpa_enabled boolean flag so autoscalers won't scale to the configured replica count between deployments.