### PR TITLE
primary-site: add ingress resource

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.3
+version: 0.0.4
 
 appVersion: "e29ff09f68025bf55fa84718dea6842517a8507a"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.4
+version: 0.0.5
 
 appVersion: "70f49b27f1123702526d83fbc754992f578b4ca2"

--- a/charts/primary-site/templates/ingress.yaml
+++ b/charts/primary-site/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- with .Values.ingress }}
+{{- if .enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: site
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  {{- if .className }}
+  ingressClassName: {{ .className | quote }}
+  {{- end }}
+  rules:
+    - host:
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stream
+                port: 
+                  number: 8080
+{{- end }}
+{{- end }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -21,6 +21,12 @@ globals:
     ## For example: us-east-1
     region: ""
 
+ingress:
+  # If you are configuring your own ingress controller, set this to 'false'
+  enabled: true
+  className:
+  annotations: {}
+
 inboxListener:
   deployment:
     replicas: 1


### PR DESCRIPTION
Provide an ingress resource with the default installation. The user can configure aspects of the ingress like annotations. The user can disable the ingress if they want to deploy their own.