### PR TITLE
Enable metrics in helm charts

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.4"
+version: "0.0.5"
 
-appVersion: "e29ff09f68025bf55fa84718dea6842517a8507a"
+appVersion: "201bbaf83eec1617bdb3951be571ac5e63e8ba77"

--- a/charts/edge-site/templates/service.yaml
+++ b/charts/edge-site/templates/service.yaml
@@ -12,5 +12,5 @@ spec:
       targetPort: 9099
     - name: metrics
       protocol: TCP
-      port: 6002
-      targetPort: 6002
+      port: 6001
+      targetPort: 6001

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.6-alpha.0
+version: 0.0.6
 
 appVersion: "201bbaf83eec1617bdb3951be571ac5e63e8ba77"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.5
+version: 0.0.6-alpha.0
 
 appVersion: "201bbaf83eec1617bdb3951be571ac5e63e8ba77"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: 0.0.5
 
-appVersion: "70f49b27f1123702526d83fbc754992f578b4ca2"
+appVersion: "201bbaf83eec1617bdb3951be571ac5e63e8ba77"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -29,8 +29,10 @@ spec:
                     name: cloud-credentials
                     optional: true
               env:
+                {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: /secrets/credentials.json
+                {{ end }}
                 - name: FOXGLOVE_API_URL
                   value: "{{ .Values.globals.foxgloveApiUrl }}"
                 - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -48,8 +48,10 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
+            {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
+            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
         app: inbox-listener
+        {{- with .Values.inboxListener.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       volumes:
         - name: cloud-credentials

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -37,6 +37,9 @@ spec:
           volumeMounts:
             - mountPath: /secrets
               name: cloud-credentials
+          ports:
+            - name: metrics
+              containerPort: 6001
           envFrom:
             - secretRef:
                 name: cloud-credentials

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -18,8 +18,8 @@ spec:
     metadata:
       labels:
         app: inbox-listener
-        {{- with .Values.inboxListener.deployment.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := .Values.inboxListener.deployment.podLabels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       volumes:

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -13,8 +13,8 @@ spec:
     metadata:
       labels:
         app: site-controller
-        {{- with .Values.siteController.deployment.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := .Values.siteController.deployment.podLabels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       containers:

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: site-controller
+  labels:
+    app: site-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: site-controller
+  template:
+    metadata:
+      labels:
+        app: site-controller
+        {{- with .Values.siteController.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+        - name: site-controller
+          image: us-central1-docker.pkg.dev/foxglove-images/images/site-controller:{{ .Chart.AppVersion }}
+          resources:
+            requests:
+              cpu: {{ .Values.siteController.deployment.resources.requests.cpu }}
+              memory: {{ .Values.siteController.deployment.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.siteController.deployment.resources.limits.cpu }}
+              memory: {{ .Values.siteController.deployment.resources.limits.memory }}
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 6002
+          ports:
+            - name: metrics
+              containerPort: 6001
+          env:
+            - name: FOXGLOVE_API_URL
+              value: {{ .Values.globals.foxgloveApiUrl }}
+            - name: FOXGLOVE_SITE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: foxglove-site
+                  key: token
+            - name: MODE
+              value: self-managed

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -18,8 +18,8 @@ spec:
     metadata:
       labels:
         app: stream-service
-        {{- with .Values.streamService.deployment.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := .Values.streamService.deployment.podLabels }}
+        {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       volumes:

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -35,7 +35,10 @@ spec:
               cpu: {{ .Values.streamService.deployment.resources.limits.cpu }}
               memory: {{ .Values.streamService.deployment.resources.limits.memory }}
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 6001
           volumeMounts:
             - mountPath: /secrets
               name: cloud-credentials

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -50,8 +50,10 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
+            {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
+            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: PORT

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       labels:
         app: stream-service
+        {{- with .Values.streamService.deployment.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       volumes:
         - name: cloud-credentials

--- a/charts/primary-site/templates/services/stream.yaml
+++ b/charts/primary-site/templates/services/stream.yaml
@@ -5,6 +5,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8080
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: metrics
+      port: 6001
+      protocol: TCP
+      targetPort: 6001
   selector:
     app: stream-service

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -37,6 +37,7 @@ inboxListener:
       limits:
         cpu: 1000m
         memory: 1Gi
+    podLabels: {}
 
 streamService:
   deployment:
@@ -48,6 +49,18 @@ streamService:
       limits:
         cpu: 1000m
         memory: 1Gi
+    podLabels: {}
+
+siteController:
+  deployment:
+    resources:
+      requests:
+        cpu: 250m
+        memory: 250Mi
+      limits:
+        cpu: 250m
+        memory: 250Mi
+    podLabels: {}
 
 garbageCollector:
   schedule: "*/10 * * * *" # every 10 minutes


### PR DESCRIPTION
Adds a deployment template for the site controller, with a metrics port
associated with the pod. Enables users to put custom pod labels on the
inbox listener, stream service, and site controller, so that they may
opt these deployments into scraping executed by some external framework
on the basis of labels.

For instance, if a prometheus PodMonitor is set up to scrape pods with
label monitoring: true, this can now be accomplished through the chart.