### PR TITLE
enhancement(Ingress): tls config for the primary site

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.7
+version: 0.0.8
 
 appVersion: "d0f1484ad9da5ab77ed08e07169e46a3ceab3777"

--- a/charts/primary-site/templates/ingress.yaml
+++ b/charts/primary-site/templates/ingress.yaml
@@ -12,6 +12,9 @@ spec:
   {{- if .className }}
   ingressClassName: {{ .className | quote }}
   {{- end }}
+  {{- if .tls }}
+  tls: {{- .tls | toYaml | trim | nindent 4 }}
+  {{- end }}
   rules:
     - host:
       http:

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -30,7 +30,7 @@ ingress:
   tls:
     ## E.g.:
     ## - hosts:
-    ##   - azure-demo.foxglove.dev
+    ##   - www.example.com
     ##   secretName: ingress-tls-csi
 
 inboxListener:

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -22,10 +22,16 @@ globals:
     region: ""
 
 ingress:
-  # If you are configuring your own ingress controller, set this to 'false'
+  ## If you are configuring your own ingress controller, set this to 'false'
   enabled: true
   className:
   annotations: {}
+  ## This section is only required if TLS is to be enabled for this ingress
+  tls:
+    ## E.g.:
+    ## - hosts:
+    ##   - azure-demo.foxglove.dev
+    ##   secretName: ingress-tls-csi
 
 inboxListener:
   deployment:


### PR DESCRIPTION
**Public-Facing Changes**

Adds a `tls` section to the Ingress config as well as to the example `values.yaml`

For context, when running the services on Azure AKS, ssl is likely to be terminated on the ingress controller. Until now, our implementation didn't have a way to customize the `tls` section there — this PR is to remedy that.