### PR TITLE
Add new edge controller metrics and support

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: "0.0.8"
 
-appVersion: "4cccbcff2db5847b8da96597bc31f1aac6077bb0"
+appVersion: "bbca57398c623abfd845c14ed23d56fc80ac5679"

--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.7"
+version: "0.0.8"
 
-appVersion: "e254b6c594391c9e378330871b20fb74f1bba1e1"
+appVersion: "4cccbcff2db5847b8da96597bc31f1aac6077bb0"

--- a/charts/edge-site/templates/service.yaml
+++ b/charts/edge-site/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: edge-controller
+  labels:
+    app: foxglove-edge-site
+    {{- range $key, $value := .Values.edgeController.serviceLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   selector:
     app: foxglove-edge-site

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -61,3 +61,7 @@ spec:
               value: "{{ .Values.globals.upload.provider }}"
             - name: INBOX_BUCKET_NAME
               value: "{{ .Values.globals.upload.bucketName }}"
+            - name: PROMETHEUS_METRICS_NAMESPACE
+              value: "{{ .Values.edgeController.metrics.namespace }}"
+            - name: PROMETHEUS_METRICS_SUBSYSTEM
+              value: "{{ .Values.edgeController.metrics.subsystem }}"

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -22,3 +22,7 @@ globals:
 edgeController:
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
+  metrics:
+    namespace: ""
+    subsystem: ""
+  serviceLabels: {}

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: 0.0.9
 
-appVersion: "4cccbcff2db5847b8da96597bc31f1aac6077bb0"
+appVersion: "bbca57398c623abfd845c14ed23d56fc80ac5679"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.8
+version: 0.0.9
 
-appVersion: "d0f1484ad9da5ab77ed08e07169e46a3ceab3777"
+appVersion: "4cccbcff2db5847b8da96597bc31f1aac6077bb0"

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -78,3 +78,7 @@ spec:
               value: "{{ .Values.globals.aws.region }}"
             - name: AWS_SDK_LOAD_CONFIG
               value: "true"
+            - name: PROMETHEUS_METRICS_NAMESPACE
+              value: "{{ .Values.inboxListener.deployment.metrics.namespace }}"
+            - name: PROMETHEUS_METRICS_SUBSYSTEM
+              value: "{{ .Values.inboxListener.deployment.metrics.subsystem }}"

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -44,3 +44,7 @@ spec:
                   key: token
             - name: MODE
               value: self-managed
+            - name: PROMETHEUS_METRICS_NAMESPACE
+              value: {{ .Values.siteController.deployment.metrics.namespace }}
+            - name: PROMETHEUS_METRICS_SUBSYSTEM
+              value: {{ .Values.siteController.deployment.metrics.subsystem }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -68,6 +68,10 @@ spec:
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL
               value: "{{ .Values.globals.azure.serviceUrl }}"
+            - name: PROMETHEUS_METRICS_NAMESPACE
+              value: "{{ .Values.streamService.deployment.metrics.namespace }}"
+            - name: PROMETHEUS_METRICS_SUBSYSTEM
+              value: "{{ .Values.streamService.deployment.metrics.subsystem }}"
           readinessProbe:
             httpGet:
               path: /liveness

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -44,6 +44,10 @@ inboxListener:
         cpu: 1000m
         memory: 1Gi
     podLabels: {}
+    metrics:
+      namespace: ""
+      subsystem: ""
+
 
 streamService:
   deployment:
@@ -56,6 +60,9 @@ streamService:
         cpu: 1000m
         memory: 1Gi
     podLabels: {}
+    metrics:
+      namespace: ""
+      subsystem: ""
 
 siteController:
   deployment:
@@ -67,6 +74,9 @@ siteController:
         cpu: 250m
         memory: 250Mi
     podLabels: {}
+    metrics:
+      namespace: ""
+      subsystem: ""
 
 garbageCollector:
   schedule: "*/10 * * * *" # every 10 minutes


### PR DESCRIPTION
Bumps versions to add new metrics to the edge controller, documented here: https://github.com/foxglove/website/pull/1003. Adds service labels to the edge controller service. Adds configuration ability for namespace/subsystem of the metrics, which will allow the user to add scoping to the names in prometheus.