### PR TITLE
Allow setting annotations on primary site services

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.9
+version: 0.0.10
 
 appVersion: "bbca57398c623abfd845c14ed23d56fc80ac5679"

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -21,6 +21,10 @@ spec:
         {{- range $key, $value := .Values.inboxListener.deployment.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.inboxListener.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       volumes:
         - name: cloud-credentials

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -16,6 +16,10 @@ spec:
         {{- range $key, $value := .Values.siteController.deployment.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.siteController.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
         - name: site-controller

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -21,6 +21,10 @@ spec:
         {{- range $key, $value := .Values.streamService.deployment.podLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.streamService.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       volumes:
         - name: cloud-credentials

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -44,6 +44,7 @@ inboxListener:
         cpu: 1000m
         memory: 4Gi
     podLabels: {}
+    podAnnotations: {}
     metrics:
       namespace: ""
       subsystem: ""
@@ -60,6 +61,7 @@ streamService:
         cpu: 1000m
         memory: 2Gi
     podLabels: {}
+    podAnnotations: {}
     metrics:
       namespace: ""
       subsystem: ""
@@ -74,6 +76,7 @@ siteController:
         cpu: 250m
         memory: 250Mi
     podLabels: {}
+    podAnnotations: {}
     metrics:
       namespace: ""
       subsystem: ""


### PR DESCRIPTION
**Public-Facing Changes**
This PR updates the primary site chart to allow setting custom annotations.

**Description**
In our EKS cluster we're using [AWS Distro for OpenTelemetry](https://aws-otel.github.io/) to scrape metrics from Foxglove services. Most of the default ADOT collector configurations make use of [`<kubernetes_sd_config>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) to find scrape targets, it seems to be the popular pattern in AWS documentation. Pods to be monitored need to be annotated as shown below to make that work

```yaml
prometheus.io/scrape: true
prometheus.io/port: 6001
prometheus.io/path: /metrics
```