### PR TITLE
Add `host` value to ingress

### DIFF
--- a/charts/primary-site/templates/ingress.yaml
+++ b/charts/primary-site/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
   tls: {{- .tls | toYaml | trim | nindent 4 }}
   {{- end }}
   rules:
-    - host:
+    - host: {{ .host }}
       http:
         paths:
           - path: /

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -26,6 +26,8 @@ ingress:
   enabled: true
   className:
   annotations: {}
+  # set the host value for an ingress
+  host:
   ## This section is only required if TLS is to be enabled for this ingress
   tls:
     ## E.g.:


### PR DESCRIPTION
Allow a deployer to override the host value for an ingress