### PR TITLE
Remove conditional env var for GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.11
+version: 0.0.12
 
 appVersion: "bbca57398c623abfd845c14ed23d56fc80ac5679"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -29,8 +29,13 @@ spec:
                     name: cloud-credentials
                     optional: true
               env:
+                {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+                ## The lookup is required here. The pod may have access to GCP through other means, but
+                ## the credentials in this env var take precedence, even if it's empty. An empty variable
+                ## essentially blocks GCP access.
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: /secrets/credentials.json
+                {{ end }}
                 - name: FOXGLOVE_API_URL
                   value: "{{ .Values.globals.foxgloveApiUrl }}"
                 - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -29,10 +29,8 @@ spec:
                     name: cloud-credentials
                     optional: true
               env:
-                {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
                 - name: GOOGLE_APPLICATION_CREDENTIALS
                   value: /secrets/credentials.json
-                {{ end }}
                 - name: FOXGLOVE_API_URL
                   value: "{{ .Values.globals.foxgloveApiUrl }}"
                 - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -52,8 +52,13 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
+            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+            ## The lookup is required here. The pod may have access to GCP through other means, but
+            ## the credentials in this env var take precedence, even if it's empty. An empty variable
+            ## essentially blocks GCP access.
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
+            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -52,10 +52,8 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
-            {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
-            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: FOXGLOVE_SITE_TOKEN

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -54,10 +54,8 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
-            {{ with lookup "v1" "Secret" .Release.Namespace "cloud-credentials" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
-            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: PORT

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -54,8 +54,13 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
+            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+            ## The lookup is required here. The pod may have access to GCP through other means, but
+            ## the credentials in this env var take precedence, even if it's empty. An empty variable
+            ## essentially blocks GCP access.
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /secrets/credentials.json
+            {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: PORT


### PR DESCRIPTION
**Public-Facing Changes**

Now uses the correct secret `gcp-cloud-credentials` in the lookup. I also added comments to ensure we don't accidentally remove the lookup and cause mayhem.