### PR TITLE
Fix GCP cloud credential secret

### DIFF
--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -29,7 +29,7 @@ spec:
                     name: cloud-credentials
                     optional: true
               env:
-                {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+                {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
                 ## The lookup is required here. The pod may have access to GCP through other means, but
                 ## the credentials in this env var take precedence, even if it's empty. An empty variable
                 ## essentially blocks GCP access.

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -52,7 +52,7 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
-            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
             ## The lookup is required here. The pod may have access to GCP through other means, but
             ## the credentials in this env var take precedence, even if it's empty. An empty variable
             ## essentially blocks GCP access.

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -54,7 +54,7 @@ spec:
                 name: cloud-credentials
                 optional: true
           env:
-            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credentials" }}
+            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
             ## The lookup is required here. The pod may have access to GCP through other means, but
             ## the credentials in this env var take precedence, even if it's empty. An empty variable
             ## essentially blocks GCP access.


### PR DESCRIPTION
Prior to this commit, the name of the credential secret was mispluralized in the inbox listener's lookup call.