### PR TITLE
edge-controller: add env vars to configure minio as storage provider

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.11"
+version: "0.0.11-alpha.0"
 
-appVersion: "ecb70141ec944f34ac215d6d10cdfe41ef3a4b1a"
+appVersion: "334b6bc799526c63ba4f7ccacb31a0ad4240a2e4"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -37,8 +37,10 @@ spec:
               memory: {{ .Values.edgeController.resources.limits.memory }}
               cpu: {{ .Values.edgeController.resources.limits.cpu }}
           volumeMounts:
+            {{ if eq .Values.recordingStorage.provider "local" }}
             - mountPath: /data/storage
               name: storage-root
+            {{ end }}
             - mountPath: /data/index
               name: index-root
             - mountPath: /secrets

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
               value: sqlite://file:/data/index/foxglove.db?_journal_mode=WAL
             - name: STORAGE_ROOT
               value: /data/storage
-            - name: CONTROLLER_STORAGE_PROVIDER
+            - name: RECORDING_STORAGE_PROVIDER
               value: "{{ .Values.edgeController.storageProvider }}"
             - name: S3_COMPATIBLE_SERVICE_URL
               value: "{{ .Values.globals.s3CompatibleService.url }}"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -14,9 +14,11 @@ spec:
         app: foxglove-edge-site
     spec:
       volumes:
+        {{ if eq .Values.edgeController.storageProvider "local" }}
         - name: storage-root
           persistentVolumeClaim:
             claimName: "{{ .Values.edgeController.storageClaim }}"
+        {{ end }}
         - name: index-root
           persistentVolumeClaim:
             claimName: "{{ .Values.edgeController.indexClaim }}"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -56,6 +56,12 @@ spec:
               value: sqlite://file:/data/index/foxglove.db?_journal_mode=WAL
             - name: STORAGE_ROOT
               value: /data/storage
+            - name: CONTROLLER_STORAGE_PROVIDER
+              value: "{{ .Values.edgeController.storageProvider }}"
+            - name: S3_COMPATIBLE_SERVICE_URL
+              value: "{{ .Values.globals.s3CompatibleService.url }}"
+            - name: S3_COMPATIBLE_SERVICE_REGION
+              value: "{{ .Values.globals.s3CompatibleService.region }}"
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
         app: foxglove-edge-site
     spec:
       volumes:
-        {{ if eq .Values.edgeController.storageProvider "local" }}
+        {{ if eq .Values.recordingStorage.provider "local" }}
         - name: storage-root
           persistentVolumeClaim:
             claimName: "{{ .Values.edgeController.storageClaim }}"
@@ -62,11 +62,11 @@ spec:
             - name: STORAGE_ROOT
               value: /data/storage
             - name: RECORDING_STORAGE_PROVIDER
-              value: "{{ .Values.edgeController.storageProvider }}"
-            - name: S3_COMPATIBLE_SERVICE_URL
-              value: "{{ .Values.globals.s3CompatibleService.url }}"
-            - name: S3_COMPATIBLE_SERVICE_REGION
-              value: "{{ .Values.globals.s3CompatibleService.region }}"
+              value: "{{ .Values.recordingStorage.provider }}"
+            - name: RECORDING_STORAGE_S3_COMPATIBLE_SERVICE_URL
+              value: "{{ .Values.recordingStorage.s3CompatibleServiceUrl }}"
+            - name: RECORDING_STORAGE_S3_COMPATIBLE_SERVICE_REGION
+              value: "{{ .Values.recordingStorage.s3CompatibleServiceRegion }}"
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -45,6 +45,9 @@ spec:
             - secretRef:
                 name: cloud-credentials
                 optional: true
+            - secretRef:
+                name: recording-storage-credentials
+                optional: true
           env:
             - name: SITE_TOKEN
               valueFrom:

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -19,6 +19,14 @@ globals:
     # The bucket name where the deployment will send the requested files
     bucketName:
 
+  # If using an S3-compatible service as the controller store provider, configure its endpoint here.
+  s3CompatibleService:
+    # Url including scheme of the base API endpoint for this service. `http` and `https` schemes
+    # are supported.
+    url: ""
+    # If your service is configured with a region (eg. us-east-1), set it here.
+    region: ""
+
 edgeController:
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
@@ -32,5 +40,6 @@ edgeController:
     limits:
       memory: "256Mi"
       cpu: "250m"
+  storageProvider: "local"
   serviceLabels: {}
   env: []

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -28,6 +28,7 @@ globals:
     region: ""
 
 edgeController:
+  storageProvider: "local"
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
   metrics:
@@ -40,6 +41,5 @@ edgeController:
     limits:
       memory: "256Mi"
       cpu: "250m"
-  storageProvider: "local"
   serviceLabels: {}
   env: []

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -19,16 +19,17 @@ globals:
     # The bucket name where the deployment will send the requested files
     bucketName:
 
-  # If using an S3-compatible service as the controller store provider, configure its endpoint here.
-  s3CompatibleService:
-    # Url including scheme of the base API endpoint for this service. `http` and `https` schemes
-    # are supported.
-    url: ""
-    # If your service is configured with a region (eg. us-east-1), set it here.
-    region: ""
+# Configuration for recording storage, defaults to the persistent volume configured by
+# `edgeController.storageClaim`
+recordingStorage:
+  provider: "local"
+  # If storing recordings on an S3-compatible service, set `provider` to "s3_compatible"
+  # The service URL eg. https://my-minio-service.mycompany.com
+  s3CompatibleServiceUrl: ""
+  # If your service is configured with a region (eg. us-east-1), set it here.
+  s3CompatibleServiceRegion: ""
 
 edgeController:
-  storageProvider: "local"
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
   metrics:


### PR DESCRIPTION
### Public-Facing Changes

Allows configuration of an S3-compatible service for recording storage. 
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
