### PR TITLE
Updates deployments of edge and primary sites

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.10"
+version: "0.0.11"
 
-appVersion: "05899346dbb9ba8ea16b88eea837604a1268c587"
+appVersion: "ecb70141ec944f34ac215d6d10cdfe41ef3a4b1a"

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -33,4 +33,4 @@ edgeController:
       memory: "256Mi"
       cpu: "250m"
   serviceLabels: {}
-  env: {}
+  env: []

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.13
+version: 0.0.14
 
-appVersion: "a8ebdf835fa733d36278984e33d210b6c5cf5ad3"
+appVersion: "ecb70141ec944f34ac215d6d10cdfe41ef3a4b1a"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -50,7 +50,7 @@ inboxListener:
     metrics:
       namespace: ""
       subsystem: ""
-    env: {}
+    env: []
       # AWS_COPY_WORKER_COUNT: adjust the number of concurrent workers for
       # copying s3 objects (default: 10)
       # - name: AWS_COPY_WORKER_COUNT
@@ -78,7 +78,7 @@ streamService:
     metrics:
       namespace: ""
       subsystem: ""
-    env: {}
+    env: []
 
 siteController:
   deployment:
@@ -94,7 +94,7 @@ siteController:
     metrics:
       namespace: ""
       subsystem: ""
-    env: {}
+    env: []
 
 garbageCollector:
   schedule: "*/10 * * * *" # every 10 minutes


### PR DESCRIPTION
Update edge and primary site deployments to the latest versions. Also fix an issue with passing in env vars via a list: the default value that was in place was an empty map, and helm threw an error if that were overwritten with an array.