### PR TITLE
Allow AWS IAM roles to be connected to service accounts

### DIFF
--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -57,3 +57,6 @@ spec:
                 - name: AWS_SDK_LOAD_CONFIG
                   value: "true"
           restartPolicy: OnFailure
+          {{- if .Values.garbageCollector.deployment.serviceAccount.enabled }}
+          serviceAccount: garbage-collector-sa
+          {{- end}}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -93,3 +93,6 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote}}
             {{- end }}
+      {{- if .Values.inboxListener.deployment.serviceAccount.enabled }}
+      serviceAccount: inbox-listener-sa
+      {{- end}}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -96,3 +96,6 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 1
       terminationGracePeriodSeconds: 30
+      {{- if .Values.streamService.deployment.serviceAccount.enabled }}
+      serviceAccount: stream-service-sa
+      {{- end}}

--- a/charts/primary-site/templates/serviceaccounts/garbage-collector.yaml
+++ b/charts/primary-site/templates/serviceaccounts/garbage-collector.yaml
@@ -1,0 +1,12 @@
+{{- with .Values.garbageCollector.deployment.serviceAccount }}
+{{- if .enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garbage-collector-sa
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/primary-site/templates/serviceaccounts/inbox-listener.yaml
+++ b/charts/primary-site/templates/serviceaccounts/inbox-listener.yaml
@@ -1,0 +1,12 @@
+{{- with .Values.inboxListener.deployment.serviceAccount }}
+{{- if .enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inbox-listener-sa
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/primary-site/templates/serviceaccounts/stream-service.yaml
+++ b/charts/primary-site/templates/serviceaccounts/stream-service.yaml
@@ -1,0 +1,12 @@
+{{- with .Values.streamService.deployment.serviceAccount }}
+{{- if .enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stream-service-sa
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -61,6 +61,16 @@ inboxListener:
       # - name: AWS_COPY_PART_SIZE_BYTES
       #   value: 104857600
 
+    serviceAccount:
+      enabled: false
+      annotations: {}
+      ## Service accounts are not required by default. You can use them on AWS to allow
+      ## the deployment assume an IAM role.
+      ## E.g:
+      ## enabled: true
+      ## annotations:
+      ##   eks.amazonaws.com/role-arn: arn:aws:iam::xxxxxxxxxxxx:role/foxglove-inbox-listener-sa-role
+
 streamService:
   service:
     annotations: {}
@@ -79,6 +89,15 @@ streamService:
       namespace: ""
       subsystem: ""
     env: []
+    serviceAccount:
+      enabled: false
+      annotations: {}
+      ## Service accounts are not required by default. You can use them on AWS to allow
+      ## the deployment assume an IAM role.
+      ## E.g:
+      ## enabled: true
+      ## annotations:
+      ##   eks.amazonaws.com/role-arn: arn:aws:iam::xxxxxxxxxxxx:role/foxglove-stream-service-sa-role
 
 siteController:
   deployment:
@@ -100,3 +119,13 @@ garbageCollector:
   schedule: "*/10 * * * *" # every 10 minutes
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
+  deployment:
+    serviceAccount:
+      enabled: false
+      annotations: {}
+      ## Service accounts are not required by default. You can use them on AWS to allow
+      ## the deployment assume an IAM role.
+      ## E.g:
+      ## enabled: true
+      ## annotations:
+      ##   eks.amazonaws.com/role-arn: arn:aws:iam::xxxxxxxxxxxx:role/foxglove-garbage-collector-sa-role


### PR DESCRIPTION
### Public-Facing Changes

This PR will allow the user to create service accounts on request, and then set custom annotations so that pods can assume IAM roles through their associated service accounts.

For the  `inbox-listener`, `stream-service` and `garbage-collector` services, we introduce here a new configuration in `values.yaml`:

```
serviceAccounts:
  enabled: true
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::xxxxxxxxxxxx:role/foxglove-inbox-listener-sa-role
```

Works in tandem with [terraform example]