### PR TITLE
primary site chart version bump to 0.0.15

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.14
+version: 0.0.15
 
 appVersion: "ecb70141ec944f34ac215d6d10cdfe41ef3a4b1a"


### PR DESCRIPTION
### Public-Facing Changes

Primary site chart version bump to 0.0.15 — forgot to do this in the AWS PR, sorry!

Previous action failed on this: https://github.com/foxglove/helm-charts/actions/runs/4504054942