### PR TITLE
FG-3060: Add Env Overrides to Garbage Collector Job

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.18
+version: 0.0.19
 
 appVersion: "fc4f64379b06aa495589105e57ef3696e2c50824"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -58,6 +58,10 @@ spec:
                   value: "{{ .Values.globals.aws.region }}"
                 - name: AWS_SDK_LOAD_CONFIG
                   value: "true"
+                {{- range $item := .Values.garbageCollector.deployment.env }}
+                - name: {{ $item.name }}
+                  value: {{ $item.value | quote}}
+                {{- end }}
           restartPolicy: OnFailure
           {{- if .Values.garbageCollector.deployment.serviceAccount.enabled }}
           serviceAccount: garbage-collector

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -120,6 +120,7 @@ garbageCollector:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   deployment:
+    env: []
     serviceAccount:
       enabled: false
       annotations: {}


### PR DESCRIPTION
### Public-Facing Changes

There should be no public facing changes to existing deployments, however this now enables adding environment variables to the garbage collector via values.yaml.

### Description

Add the same env override section as seen in other services to the garbage collector.

### Testing

Tested locally to confirm that this will not break an existing deployment.
