### PR TITLE
Make AWS multipart writer part size configurable

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: 0.0.20
+version: 0.0.21
 
-appVersion: "e96c77bc14106ae9dd7365cb209935b7aac06717"
+appVersion: "4da7e6834a3753878c5e9d9176d3fca442d6dfad"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -60,6 +60,11 @@ inboxListener:
       # sizes (default 100MB)
       # - name: AWS_COPY_PART_SIZE_BYTES
       #   value: 104857600
+      # AWS_WRITER_PART_SIZE_BYTES: size in bytes of multipart write part
+      # sizes. This influences the size of a buffer created per-topic in the
+      # inbox listener.
+      # - name: AWS_WRITER_PART_SIZE_BYTES
+      #   value: 5242880
 
     serviceAccount:
       enabled: false


### PR DESCRIPTION
Bumps the image for primary sites to incorporate latest bug fix from data-platform.