### PR TITLE
FG-3744: Support User-Provided Secrets in Helm Charts

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.17"
+version: "0.0.18"
 
 appVersion: "e7b0c025f49d6421b2c74070713b21ee7b94d609"

--- a/charts/edge-site/templates/secret.yaml
+++ b/charts/edge-site/templates/secret.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.globals.siteToken }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: foxglove-site
 type: Opaque
 data:
-  token: "{{ required "A valid siteToken is required!" .Values.globals.siteToken | b64enc }}"
+  token: "{{ .Values.globals.siteToken | b64enc }}"
+{{- end }}

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -52,6 +52,9 @@ spec:
             - secretRef:
                 name: recording-storage-credentials
                 optional: true
+            - secretRef:
+                name: foxglove-site-token
+                optional: true
             {{- range $k := .Values.globals.secrets }}
             - secretRef:
                 name: {{ $k }}

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -52,13 +52,19 @@ spec:
             - secretRef:
                 name: recording-storage-credentials
                 optional: true
+            {{- range $k := .Values.globals.secrets }}
+            - secretRef:
+                name: {{ $k }}
+            {{- end }}
           env:
+            {{- if .Values.globals.siteToken }}
             - name: SITE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: foxglove-site
                   key: token
                   optional: false
+            {{- end }}
             - name: DATABASE_CONNECTION_STRING
               value: sqlite://file:/data/index/foxglove.db?_journal_mode=WAL
             - name: STORAGE_ROOT

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -2,7 +2,17 @@
 
 globals:
   # The site token provides authentication to the foxglove api for the deployment
+  # DEPRECATED: Instead, define a Secret containing FOXGLOVE_SITE_TOKEN and include
+  # it in the list below.
   siteToken:
+
+  # Environment Secrets
+  # List installed Secrets in the foxglove namespace that will be loaded as
+  # environment variables. A single Secret can contain multiple values.
+  secrets:
+  ## E.g.:
+  ## - foxglove-site-token
+  ## - arbitrary-secret
 
   # The api endpoint the deployment will use as the control plane
   foxgloveApiUrl: https://api.foxglove.dev

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -1,18 +1,13 @@
 # Default values for edge-site.
 
 globals:
-  # The site token provides authentication to the foxglove api for the deployment
-  # DEPRECATED: Instead, define a Secret containing FOXGLOVE_SITE_TOKEN and include
-  # it in the list below.
-  siteToken:
-
   # Environment Secrets
   # List installed Secrets in the foxglove namespace that will be loaded as
-  # environment variables. A single Secret can contain multiple values.
+  # environment variables. A single Secret can contain multiple key-value pairs.
   secrets:
   ## E.g.:
-  ## - foxglove-site-token
   ## - arbitrary-secret
+  ## - another-secret
 
   # The api endpoint the deployment will use as the control plane
   foxgloveApiUrl: https://api.foxglove.dev

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.23"
+version: "0.0.24"
 
 appVersion: "e7b0c025f49d6421b2c74070713b21ee7b94d609"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -28,6 +28,10 @@ spec:
                 - secretRef:
                     name: cloud-credentials
                     optional: true
+                {{- range $k := .Values.globals.secrets }}
+                - secretRef:
+                    name: {{ $k }}
+                {{- end }}
               env:
                 {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
                 ## The lookup is required here. The pod may have access to GCP through other means, but
@@ -38,12 +42,14 @@ spec:
                 {{ end }}
                 - name: FOXGLOVE_API_URL
                   value: "{{ .Values.globals.foxgloveApiUrl }}"
+                {{- if .Values.globals.siteToken }}
                 - name: FOXGLOVE_SITE_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: foxglove-site
                       key: token
                       optional: false
+                {{- end }}
                 - name: MODE
                   value: self-managed
                 - name: STORAGE_LAKE_BUCKET_NAME

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -28,6 +28,9 @@ spec:
                 - secretRef:
                     name: cloud-credentials
                     optional: true
+                - secretRef:
+                    name: foxglove-site-token
+                    optional: true
                 {{- range $k := .Values.globals.secrets }}
                 - secretRef:
                     name: {{ $k }}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -51,6 +51,9 @@ spec:
             - secretRef:
                 name: cloud-credentials
                 optional: true
+            - secretRef:
+                name: foxglove-site-token
+                optional: true
             {{- range $k := .Values.globals.secrets }}
             - secretRef:
                 name: {{ $k }}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -51,6 +51,10 @@ spec:
             - secretRef:
                 name: cloud-credentials
                 optional: true
+            {{- range $k := .Values.globals.secrets }}
+            - secretRef:
+                name: {{ $k }}
+            {{- end }}
           env:
             {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
             ## The lookup is required here. The pod may have access to GCP through other means, but
@@ -61,12 +65,14 @@ spec:
             {{ end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
+            {{- if .Values.globals.siteToken }}
             - name: FOXGLOVE_SITE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: foxglove-site
                   key: token
                   optional: false
+            {{- end }}
             - name: MODE
               value: self-managed
             - name: INBOX_STORAGE_PROVIDER

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -41,11 +41,13 @@ spec:
           env:
             - name: FOXGLOVE_API_URL
               value: {{ .Values.globals.foxgloveApiUrl }}
+            {{- if .Values.globals.siteToken }}
             - name: FOXGLOVE_SITE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: foxglove-site
                   key: token
+            {{- end }}
             - name: MODE
               value: self-managed
             - name: PROMETHEUS_METRICS_NAMESPACE

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -38,6 +38,10 @@ spec:
           ports:
             - name: metrics
               containerPort: 6001
+          envFrom:
+            - secretRef:
+                name: foxglove-site-token
+                optional: true
           env:
             - name: FOXGLOVE_API_URL
               value: {{ .Values.globals.foxgloveApiUrl }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -53,6 +53,9 @@ spec:
             - secretRef:
                 name: cloud-credentials
                 optional: true
+            - secretRef:
+                name: foxglove-site-token
+                optional: true
             {{- range $k := .Values.globals.secrets }}
             - secretRef:
                 name: {{ $k }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -53,6 +53,10 @@ spec:
             - secretRef:
                 name: cloud-credentials
                 optional: true
+            {{- range $k := .Values.globals.secrets }}
+            - secretRef:
+                name: {{ $k }}
+            {{- end }}
           env:
             {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
             ## The lookup is required here. The pod may have access to GCP through other means, but

--- a/charts/primary-site/templates/secret.yaml
+++ b/charts/primary-site/templates/secret.yaml
@@ -1,7 +1,9 @@
+{{- if .Values.globals.siteToken }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: foxglove-site
 type: Opaque
 data:
-  token: {{ required "A valid siteToken is required!" .Values.globals.siteToken | b64enc }}
+  token: "{{ .Values.globals.siteToken | b64enc }}"
+{{- end }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,16 +1,11 @@
 globals:
-  # The site token provides authentication to the foxglove api for the deployment
-  # DEPRECATED: Instead, define a Secret containing FOXGLOVE_SITE_TOKEN and include
-  # it in the list below.
-  siteToken:
-
   # Environment Secrets
   # List installed Secrets in the foxglove namespace that will be loaded as
-  # environment variables. A single Secret can contain multiple values.
+  # environment variables. A single Secret can contain multiple key-value pairs.
   secrets:
   ## E.g.:
-  ## - foxglove-site-token
   ## - arbitrary-secret
+  ## - another-secret
 
   foxgloveApiUrl: https://api.foxglove.dev
 

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -1,5 +1,17 @@
 globals:
+  # The site token provides authentication to the foxglove api for the deployment
+  # DEPRECATED: Instead, define a Secret containing FOXGLOVE_SITE_TOKEN and include
+  # it in the list below.
   siteToken:
+
+  # Environment Secrets
+  # List installed Secrets in the foxglove namespace that will be loaded as
+  # environment variables. A single Secret can contain multiple values.
+  secrets:
+  ## E.g.:
+  ## - foxglove-site-token
+  ## - arbitrary-secret
+
   foxgloveApiUrl: https://api.foxglove.dev
 
   ## Supported storageProvider values are: `google_cloud`, `aws` or `azure`


### PR DESCRIPTION
### User-Facing Changes

Customers deploying a primary site or an edge site will be able to define Kubernetes Secrets to load as environment variables by listing them in `.Values.globals.secrets`. This is primarily so that customers do not have to include the Foxglove site token in plain text in values.yaml, however it allows for supporting other customer-provided secrets. The existing method of using `.Values.globals.site_token` will still work until we can safely remove it.

### Description

Adds a new section in values.yaml to define Kubernetes Secrets that will be loaded into the environment for all containers via   envFrom directives. Wraps all of the code that currently depends on `.Values.globals.site_token` in conditional blocks so that if `site_token` is blank they are not evaluated. The edge controller now supports both FOXGLOVE_SITE_TOKEN and SITE_TOKEN.
