### PR TITLE
FG-4471: Add podAnnotations to Edge Site Helm Chart

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.18"
+version: "0.0.19"
 
 appVersion: "e7b0c025f49d6421b2c74070713b21ee7b94d609"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -12,6 +12,13 @@ spec:
     metadata:
       labels:
         app: foxglove-edge-site
+        {{- range $key, $value := .Values.edgeController.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.edgeController.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       volumes:
         {{ if eq .Values.recordingStorage.provider "local" }}

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -50,5 +50,7 @@ edgeController:
     limits:
       memory: "256Mi"
       cpu: "250m"
+  podLabels: {}
+  podAnnotations: {}
   serviceLabels: {}
   env: []


### PR DESCRIPTION
### Public-Facing Changes

Enables adding pod annotations to the edge controller for edge site installations

### Description

Adds podAnnotations and podLabels keys to values.yaml, enabling these keys to be added to the edge controller statefulset.