### PR TITLE
Edge controller: only define GCP credentials env var when secret exists

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.20"
+version: "0.0.21"
 
 appVersion: "052deed519997067843d79b3651fe5bc68eed4fb"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -75,6 +75,13 @@ spec:
                   key: token
                   optional: false
             {{- end }}
+            ## The lookup is required here. The pod may have access to GCP through other means, but
+            ## the credentials in this env var take precedence, even if it's empty. An empty variable
+            ## essentially blocks GCP access.
+            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/credentials.json
+            {{ end }}
             - name: DATABASE_CONNECTION_STRING
               value: sqlite://file:/data/index/foxglove.db?_journal_mode=WAL
             - name: STORAGE_ROOT
@@ -89,8 +96,6 @@ spec:
               value: "{{ .Values.recordingStorage.s3CompatibleServiceRegion }}"
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /secrets/credentials.json
             - name: AWS_SDK_LOAD_CONFIG
               value: "true"
             - name: AWS_REGION


### PR DESCRIPTION
This is what we do for the other charts as well, and makes it possible to use the edge controller from e.g minikube using CLI credentials in a testing context. This is convenient for development and for potential users who just want to kick the tires without provisioning service accounts.