### PR TITLE
FG-5079: Update Stream Service Probes

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.29"
+version: "0.0.30"
 
 appVersion: "42e9227b91cfee75f68ea95ed24f4a66d0080645"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -90,18 +90,29 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote}}
             {{- end }}
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: "/liveness"
+            # Ping every second until ready, up to 30s.
+            initialDelaySeconds: 0
+            periodSeconds: 1
+            timeoutSeconds: 1
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /liveness
               port: 8080
             periodSeconds: 3
             timeoutSeconds: 1
+            failureThreshold: 10
           livenessProbe:
             httpGet:
               path: /liveness
               port: 8080
             periodSeconds: 3
             timeoutSeconds: 1
+            failureThreshold: 20
       terminationGracePeriodSeconds: 30
       {{- if .Values.streamService.deployment.serviceAccount.enabled }}
       serviceAccount: stream-service


### PR DESCRIPTION
### Public-Facing Changes

Updates Stream Service probes to allow for a longer window before terminating the pod.

### Description

The default failureThreshold for Kubernetes probes is 3, meaning the stream service would be terminated after ~12 seconds of not responding to requests. This change ups that threshold to 10 failures before the pod is removed from taking requests and 20 failures before it is terminated.