### PR TITLE
Add support for nodeSelector on deployments

### DIFF
--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -75,3 +75,8 @@ spec:
           {{- if .Values.garbageCollector.deployment.serviceAccount.enabled }}
           serviceAccount: garbage-collector
           {{- end}}
+          nodeSelector:
+            {{- range $key, $value := .Values.inboxListener.deployment.nodeSelectors }}
+            {{ $key }}: {{ $value | quote }}
+            {{- end }}
+          {{- end}}

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -75,8 +75,9 @@ spec:
           {{- if .Values.garbageCollector.deployment.serviceAccount.enabled }}
           serviceAccount: garbage-collector
           {{- end}}
+          {{- if .Values.garbageCollector.deployment.nodeSelectors }}
           nodeSelector:
-            {{- range $key, $value := .Values.inboxListener.deployment.nodeSelectors }}
+            {{- range $key, $value := .Values.garbageCollector.deployment.nodeSelectors }}
             {{ $key }}: {{ $value | quote }}
             {{- end }}
           {{- end}}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -105,7 +105,7 @@ spec:
       {{- if .Values.inboxListener.deployment.serviceAccount.enabled }}
       serviceAccount: inbox-listener
       {{- end}}
-      {{- if ne .Values.inboxListener.deployment.nodeSelectors {} }}
+      {{- if .Values.inboxListener.deployment.nodeSelectors }}
       nodeSelector:
         {{- range $key, $value := .Values.inboxListener.deployment.nodeSelectors }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -62,7 +62,7 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote}}
             {{- end }}
-      {{- if ne .Values.siteController.deployment.nodeSelectors {} }}
+      {{- if .Values.siteController.deployment.nodeSelectors }}
       nodeSelector:
         {{- range $key, $value := .Values.siteController.deployment.nodeSelectors }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -117,7 +117,7 @@ spec:
       {{- if .Values.streamService.deployment.serviceAccount.enabled }}
       serviceAccount: stream-service
       {{- end}}
-      {{- if ne .Values.streamService.deployment.nodeSelectors {} }}
+      {{- if .Values.streamService.deployment.nodeSelectors }}
       nodeSelector:
         {{- range $key, $value := .Values.streamService.deployment.nodeSelectors }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -58,7 +58,8 @@ inboxListener:
     metrics:
       namespace: ""
       subsystem: ""
-    env: []
+    env:
+      []
       # AWS_COPY_WORKER_COUNT: adjust the number of concurrent workers for
       # copying s3 objects (default: 10)
       # - name: AWS_COPY_WORKER_COUNT
@@ -136,6 +137,7 @@ garbageCollector:
   successfulJobsHistoryLimit: 3
   deployment:
     env: []
+    nodeSelectors: {}
     serviceAccount:
       enabled: false
       annotations: {}


### PR DESCRIPTION
### Public-Facing Changes

Adding support for nodeSelector(s) on deployments

### Description

We are currently running two clusters, x86 and ARM64. We want to migrate to a single cluster (currently only ARM64) with an additional NodePool for x86 services, of which Foxglove is the primary. In order to target Foxglove to those nodes (and not the ARM64), we need to be able to set nodeSelectors on the deployments.
