### PR TITLE
appVersion: update to include arm64 builds

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.20"
+version: "0.0.21"
 
-appVersion: "052deed519997067843d79b3651fe5bc68eed4fb"
+appVersion: "fefab2049beaaa5fc25ae37b9f74a921b0314531"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.35"
+version: "0.0.36"
 
-appVersion: "3af304d2e476e78627a3eb5cc7eb166db46feb79"
+appVersion: "fefab2049beaaa5fc25ae37b9f74a921b0314531"


### PR DESCRIPTION
### Public-Facing Changes

* Our primary site and edge site charts can now be deployed to arm64 clusters.

#### Edge Site updates:
* https://github.com/foxglove/data-platform/pull/1050
* https://github.com/foxglove/data-platform/pull/1043
* https://github.com/foxglove/data-platform/pull/1041

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
