### PR TITLE
stream-server: point to stream-server container in registry

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.37"
+version: "0.0.38"
 
 appVersion: "083ea7cd15e5ca942125c5a3efaf0caa6fbd5d3e"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -33,7 +33,7 @@ spec:
             optional: true
       containers:
         - name: stream-service
-          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-service:{{ .Chart.AppVersion }}
+          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-server:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}


### PR DESCRIPTION
### Public-Facing Changes


### Description

- https://github.com/foxglove/data-platform/pull/1098 inadvertently changed the destination path of the stream server image from `stream-service` to `stream-server`. This is the only docker image where the image has a different name from the underlying binary. It's a small difference and was missed. However, this is causing the helm chart to fail to launch the stream server:
```
j@192-168-1-105 helm-charts % docker run us-central1-docker.pkg.dev/foxglove-images/images/stream-service:083ea7cd15e5ca942125c5a3efaf0caa6fbd5d3e   
Unable to find image 'us-central1-docker.pkg.dev/foxglove-images/images/stream-service:083ea7cd15e5ca942125c5a3efaf0caa6fbd5d3e' locally
docker: Error response from daemon: manifest for us-central1-docker.pkg.dev/foxglove-images/images/stream-service:083ea7cd15e5ca942125c5a3efaf0caa6fbd5d3e not found: manifest unknown: Failed to fetch "083ea7cd15e5ca942125c5a3efaf0caa6fbd5d3e".
See 'docker run --help'.
```
This PR changes the image path in the helm chart, which is the least-invasive change i believe will cause this to start working again.