### PR TITLE
edge-site: bump version to include schemaless support

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.25"
+version: "0.0.26"
 
-appVersion: "d6b06d218f96d2690c76d28faa860e5223a80865"
+appVersion: "b18f7dbdf4a43ab47e3a84c2f5fc301b63923b3d"


### PR DESCRIPTION
### Changelog
- foxglove/data-platform#1178
- foxglove/data-platform#1173
### Docs

None.

### Description

Update the edge controller to include schemaless MCAP support and to remove message count functionality.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

