### PR TITLE
Edge site bump to fix deviceName pattern

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.26"
+version: "0.0.27"
 
-appVersion: "b18f7dbdf4a43ab47e3a84c2f5fc301b63923b3d"
+appVersion: "52635113b2661b6a9df94889eea5d1284df41ced"

--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: "0.0.27"
 
-appVersion: "52635113b2661b6a9df94889eea5d1284df41ced"
+appVersion: "eaa9e6d083ab3fe828d28dc71ac3b64cd341eb69"


### PR DESCRIPTION
### Changelog

Fixed: the device name pattern no longer allows `~`
Fixed: treat an undefined `retainRecordingsSeconds` as indefinite

### Docs

None. Documented by the public device API.

### Description

<!--https://github.com/foxglove/data-platform/commit/52635113b2661b6a9df94889eea5d1284df41ced-->
https://github.com/foxglove/data-platform/commit/eaa9e6d083ab3fe828d28dc71ac3b64cd341eb69