### PR TITLE
give metrics a prefix/namespace and subsystem by default

### DIFF
--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -41,8 +41,8 @@ edgeController:
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
   metrics:
-    namespace: ""
-    subsystem: ""
+    namespace: "foxglove_data_platform"
+    subsystem: "edge_controller"
   resources:
     requests:
       memory: "256Mi"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -56,8 +56,8 @@ inboxListener:
     podAnnotations: {}
     nodeSelectors: {}
     metrics:
-      namespace: ""
-      subsystem: ""
+      namespace: "foxglove_data_platform"
+      subsystem: "inbox_listener"
     env:
       []
       # AWS_COPY_WORKER_COUNT: adjust the number of concurrent workers for
@@ -113,8 +113,8 @@ streamService:
     podAnnotations: {}
     nodeSelectors: {}
     metrics:
-      namespace: ""
-      subsystem: ""
+      namespace: "foxglove_data_platform"
+      subsystem: "stream_service"
     env: []
     serviceAccount:
       enabled: false
@@ -139,8 +139,8 @@ siteController:
     podAnnotations: {}
     nodeSelectors: {}
     metrics:
-      namespace: ""
-      subsystem: ""
+      namespace: "foxglove_data_platform"
+      subsystem: "site_controller"
     env: []
 
 garbageCollector:


### PR DESCRIPTION
### Changelog

Prometheus metrics will now have a default prefix and subsystem. Old behavior can be restored by removing the changed metrics subsystem and namespace in `values.yaml`.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Metrics named i.e. `stream_sync_ms`

</td><td>

Metrics named i.e. `foxglove_data_platform_stream_sync_ms`
<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

