### PR TITLE
Bump primary site to v0.0.42

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.41"
+version: "0.0.42"
 
-appVersion: "610223e5f22ba95225f598df955e578e839f8d9a"
+appVersion: "d3727462d51adb4d9a01808ecb4e0b08e26f4459"
 
 


### PR DESCRIPTION
### Changelog

#### Inbox listener

Fixed: recordings with no device ID and no specified key are imported correctly. Previously, they were incorrectly de-duplicated.

### Docs

None.
