### PR TITLE
Bump primary site to v0.0.43

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,8 +13,8 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.42"
+version: "0.0.43"
 
-appVersion: "d3727462d51adb4d9a01808ecb4e0b08e26f4459"
+appVersion: "a7d052fcecb10c6c1bf866e4164ee1495bf54db6"
 
 


### PR DESCRIPTION
### Changelog

#### Inbox listener

Fixed: ensure the storage object writer closes successfully when writing mcap metadata. Previously, the error was suppressed, and a metadata file could fail to exist in the lake.

### Docs

None