### PR TITLE
Primary site: release v0.0.46

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.45"
+version: "0.0.46"
 
-appVersion: "daf59710c2873a65ec5e551a11101ccf218ffbe1"
+appVersion: "93273ddcd2bc95a010257dea19c97f9a8579a87b"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -76,8 +76,12 @@ spec:
               value: "{{ .Values.globals.aws.region }}"
             - name: AWS_SDK_LOAD_CONFIG
               value: "true"
-            - name: STORAGE_PROVIDER
+            - name: LAKE_STORAGE_PROVIDER
               value: "{{ .Values.globals.lake.storageProvider }}"
+            - name: INBOX_STORAGE_PROVIDER
+              value: "{{ .Values.globals.inbox.storageProvider }}"
+            - name: STORAGE_INBOX_BUCKET_NAME
+              value: "{{ .Values.globals.inbox.bucketName }}"
             - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL


### PR DESCRIPTION
### Changelog

- Added: support for downloading quarantined pending imports. This feature will be enabled through the UI in the near future.
  -  Note: For this to work, deployers will need to double-check permissions on their inbox bucket to make sure that their *stream service* has access to read from them.
- Added: support for retrying quarantined pending imports. This feature will be enabled through the UI in the near future.
- Fixed: if the garbage collector cannot delete a temp file, it will log an error instead of aborting.
- Fixed: the request ID tag in inbox listener logs now matches the request ID in the foxglove API for pending imports.
- Fixed: various corrupt BAG and MCAP errors will now result in the file being quarantined immediately rather than retrying 3 times.

### Docs

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

