### PR TITLE
add pollingInterval, successfulJobsHistoryLimit, failedJobsHistory values

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.47"
+version: "0.0.48"
 
 appVersion: "93273ddcd2bc95a010257dea19c97f9a8579a87b"

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   minReplicaCount: {{ .Values.inboxListener.autoscaling.minReplicas }}
   maxReplicaCount: {{ .Values.inboxListener.autoscaling.maxReplicas }}
-  successfulJobsHistoryLimit: 50
-  failedJobsHistoryLimit: 100
-  pollingInterval: 30
+  successfulJobsHistoryLimit: {{ .Values.inboxListener.autoscaling.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.inboxListener.autoscaling.failedJobsHistoryLimit }}
+  pollingInterval: {{ .Values.inboxListener.autoscaling.pollingInterval }}
   jobTargetRef:
     parallelism: 1
     activeDeadlineSeconds: 86400

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -113,6 +113,13 @@ inboxListener:
     # wait for new work items. It is unlikely that this value should be changed. The value should only be set when
     # using this auto-scaling.
     maxWaitForWork: "30s"
+    # how many successful jobs to keep in Kubernetes history, this is a safe default, but may be lowered if
+    # desired.
+    successfulJobsHistoryLimit: 50
+    # how many failed jobs to keep in Kubernetes history, this is a safe default, but may be lowered if desired.
+    failedJobsHistoryLimit: 100
+    # how often to poll the autoscaling metric, this is a safe default
+    pollingInterval: 30
 
 streamService:
   service:

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -118,7 +118,7 @@ inboxListener:
     successfulJobsHistoryLimit: 50
     # how many failed jobs to keep in Kubernetes history, this is a safe default, but may be lowered if desired.
     failedJobsHistoryLimit: 100
-    # how often to poll the autoscaling metric, this is a safe default
+    # how often to poll the autoscaling metric in seconds, provided as an integer. this is a safe default.
     pollingInterval: 30
 
 streamService:


### PR DESCRIPTION


### Changelog

inbox-listener: for built-in autoscaling, add Helm chart values to tune `pollingInterval`, `successJobsHistoryLimit` and `failedJobsHistoryLimit`

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

