### PR TITLE
primary-site: update to v0.0.49

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.48"
+version: "0.0.49"
 
-appVersion: "93273ddcd2bc95a010257dea19c97f9a8579a87b"
+appVersion: "65e83cd7ed9004d89c83e239a4c6fa8dbd4caa08"


### PR DESCRIPTION
- Added:  If the `LOG_REPEATED_IMPORT_FAILURES` environment variable is set to `true`, the inbox listener will log an error-level message whenever it has to quarantine an input file after exhausting all retries. This can help primary site operators detect issues with their deployment.
- Changed: For primary sites using Azure storage buckets with hierarchical namespaces enabled, the garbage-collector service will log an `info`-level message when it attempts to delete a non-empty directory, but it will skip over it.
- Fixed: If the inbox listener attempts to process an MCAP file with an invalid file offset, it will quarantine the file immediately rather than retrying three times.
