### PR TITLE
edge-controller: configure primary site mode through values

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.29"
+version: "0.0.30"
 
 appVersion: "65e83cd7ed9004d89c83e239a4c6fa8dbd4caa08"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -75,6 +75,8 @@ spec:
                   key: token
                   optional: false
             {{- end }}
+            - name: PRIMARY_SITE_MODE
+              value: "{{ .Values.globals.upload.primarySiteMode }}"
             - name: DATABASE_CONNECTION_STRING
               value: sqlite://file:/data/index/foxglove.db?_journal_mode=WAL
             - name: STORAGE_ROOT

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -16,16 +16,17 @@ globals:
     ## For example: us-east-1
     region: ""
 
-  # This section configures where the deployment will upload files you wish to import into a primary site
+  # This section configures where the deployment will upload files you wish to import.
   upload:
     # Upload to either a Foxglove-hosted or self-managed primary site.
     # Values: "self-managed", "hosted"
     primarySiteMode: self-managed
-    # The cloud provider where the self-managed primary site inbox bucket lives.
-    # If `primarySiteMode` is set to `hosted`, these values are ignored.
+    # The cloud provider where the self-managed primary site inbox bucket lives. Ignored if
+    # `primarySiteMode` is set to `hosted`.
     # Values: aws, azure, google_cloud
     provider:
-    # The self-managed primary site inbox bucket name
+    # The self-managed primary site inbox bucket name. Ignored if `primarySiteMode` is set to
+    # `hosted`.
     bucketName:
 
 # Configuration for recording storage, defaults to the persistent volume configured by

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -18,10 +18,14 @@ globals:
 
   # This section configures where the deployment will upload files you wish to import into a primary site
   upload:
-    # The cloud provider where the destination inbox bucket lives
-    # Values values: aws, azure, google_cloud
+    # Upload to either a Foxglove-hosted or self-managed primary site.
+    # Values: "self-managed", "hosted"
+    primarySiteMode: self-managed
+    # The cloud provider where the self-managed primary site inbox bucket lives.
+    # If `primarySiteMode` is set to `hosted`, these values are ignored.
+    # Values: aws, azure, google_cloud
     provider:
-    # The bucket name where the deployment will send the requested files
+    # The self-managed primary site inbox bucket name
     bucketName:
 
 # Configuration for recording storage, defaults to the persistent volume configured by


### PR DESCRIPTION
### Changelog

- Added: expose primary site configuration for edge controller through helm chart values.

### Docs

https://github.com/foxglove/docs/pull/481

### Description

It's possible to use an edge controller with a hosted primary site, but right now users don't have a good way to configure that. This PR plumbs through a configuration variable for this.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
