### PR TITLE
update links to documentation

### DIFF
--- a/charts/edge-site/templates/NOTES.txt
+++ b/charts/edge-site/templates/NOTES.txt
@@ -6,8 +6,8 @@ See the status of your release:
 
 Complete your site installation:
 
-    https://foxglove.dev/docs/data-platform/edge-sites/installation
+    https://docs.foxglove.dev/docs/edge-sites/installation
 
 Import data to your new site:
 
-    https://foxglove.dev/docs/data-platform/edge-sites/manage-data
+    https://docs.foxglove.dev/docs/edge-sites/manage-data

--- a/charts/primary-site/templates/NOTES.txt
+++ b/charts/primary-site/templates/NOTES.txt
@@ -6,8 +6,8 @@ See the status of your release:
 
 Complete your site installation:
 
-    https://foxglove.dev/docs/data-platform/primary-sites/installation
+    https://docs.foxglove.dev/docs/primary-sites/self-hosting/installation
 
 Import data to your new site:
 
-    https://foxglove.dev/docs/data-platform/primary-sites/manage-data
+    https://docs.foxglove.dev/docs/primary-sites/self-hosting/manage-data


### PR DESCRIPTION
### Changelog

Update links to documentation in `NOTES.txt` for charts.

### Docs

Fixes: FG-9549
<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Update links to documentation.

