### PR TITLE
bump versions of both charts with updated documentation links

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.30"
+version: "0.0.31"
 
 appVersion: "65e83cd7ed9004d89c83e239a4c6fa8dbd4caa08"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.51"
+version: "0.0.52"
 
 appVersion: "79aed2aaac91cb942467185b7c1f74454cb0fefe"


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Release `edge-site`:`0.0.31` and `primary-site`:`0.0.52`.