### PR TITLE
bump primary site to 0.0.54

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.53"
+version: "0.0.54"
 
 appVersion: "b5ab5dc7bd5ef765d43830423ea4465d3bb016b1"


### PR DESCRIPTION
### Changelog
primary-site: Add `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` support to primary site services

### Docs
None

### Description
Bump chart version with environment variable proxy support.