### PR TITLE
add volume, image, init customization support to helm charts

### DIFF
--- a/charts/edge-site/Chart.yaml
+++ b/charts/edge-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.31"
+version: "0.0.32"
 
 appVersion: "65e83cd7ed9004d89c83e239a4c6fa8dbd4caa08"

--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -33,9 +33,16 @@ spec:
           secret:
             secretName: gcp-cloud-credential
             optional: true
+        {{- if .Values.edgeController.extraVolumes }}
+          {{- toYaml .Values.edgeController.extraVolumes| nindent 8 }}
+        {{- end }}
+      {{- if .Values.edgeController.initContainers }}
+      initContainers:
+        {{- toYaml .Values.edgeController.initContainers | nindent 10 }}
+      {{- end }}
       containers:
         - name: edge-controller
-          image: us-central1-docker.pkg.dev/foxglove-images/images/edge-controller:{{ .Chart.AppVersion }}
+          image: {{ .Values.edgeController.image }}:{{ .Chart.AppVersion }}
           resources:
             requests:
               memory: {{ .Values.edgeController.resources.requests.memory }}
@@ -44,6 +51,9 @@ spec:
               memory: {{ .Values.edgeController.resources.limits.memory }}
               cpu: {{ .Values.edgeController.resources.limits.cpu }}
           volumeMounts:
+            {{- if .Values.edgeController.extraVolumeMounts }}
+              {{- toYaml .Values.edgeController.extraVolumeMounts | nindent 12 }}
+            {{- end }}
             {{ if eq .Values.recordingStorage.provider "local" }}
             - mountPath: /data/storage
               name: storage-root

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -43,6 +43,7 @@ recordingStorage:
   s3CompatibleServiceRegion: ""
 
 edgeController:
+  image: "us-central1-docker.pkg.dev/foxglove-images/images/edge-controller"
   storageClaim: edge-controller-storage-claim
   indexClaim: edge-controller-index-claim
   metrics:
@@ -59,3 +60,6 @@ edgeController:
   podAnnotations: {}
   serviceLabels: {}
   env: []
+  initContainers: []
+  extraVolumes: []
+  extraVolumeMounts: []

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.55"
+version: "0.0.56"
 
 appVersion: "b5ab5dc7bd5ef765d43830423ea4465d3bb016b1"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -18,12 +18,22 @@ spec:
               secret:
                 secretName: gcp-cloud-credential
                 optional: true
+            {{- if .Values.garbageCollector.deployment.extraVolumes }}
+              {{- toYaml .Values.garbageCollector.deployment.extraVolumes | nindent 12 }}
+            {{- end }}
+          {{- if .Values.garbageCollector.deployment.initContainers }}
+          initContainers:
+            {{- toYaml .Values.garbageCollector.deployment.initContainers | nindent 12 }}
+          {{- end }}
           containers:
             - name: garbage-collector
-              image: us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector:{{ .Chart.AppVersion }}
+              image: {{ .Values.garbageCollector.deployment.image }}:{{ .Chart.AppVersion }}
               volumeMounts:
                 - mountPath: /secrets
                   name: cloud-credentials
+                {{- if .Values.garbageCollector.deployment.extraVolumeMounts }}
+                  {{- toYaml .Values.garbageCollector.deployment.extraVolumeMounts | nindent 16 }}
+                {{- end }}
               envFrom:
                 - secretRef:
                     name: cloud-credentials

--- a/charts/primary-site/templates/deployments/_inbox-container.tpl
+++ b/charts/primary-site/templates/deployments/_inbox-container.tpl
@@ -16,6 +16,9 @@ template:
         secret:
           secretName: gcp-cloud-credential
           optional: true
+      {{- if .Values.inboxListener.deployment.extraVolumes }}
+        {{- toYaml .Values.inboxListener.deployment.extraVolumes | nindent 6 }}
+      {{- end }}
       {{- if .Values.inboxListener.deployment.localScratch.enabled }}
       - name: local-scratch
         emptyDir:
@@ -30,9 +33,13 @@ template:
     {{- if .Values.inboxListener.deployment.serviceAccount.enabled }}
     serviceAccount: inbox-listener
     {{- end}}
+    {{- if .Values.inboxListener.deployment.initContainers }}
+    initContainers:
+      {{- toYaml .Values.inboxListener.deployment.initContainers | nindent 6 }}
+    {{- end }}
     containers:
       - name: inbox-listener
-        image: us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener:{{ .Chart.AppVersion }}
+        image: {{ .Values.inboxListener.deployment.image }}:{{ .Chart.AppVersion }}
         resources:
           requests:
             cpu: {{ .Values.inboxListener.deployment.resources.requests.cpu }}
@@ -52,6 +59,9 @@ template:
           {{- if .Values.inboxListener.deployment.localScratch.enabled }}
           - mountPath: /local-scratch
             name: local-scratch
+          {{- end }}
+          {{- if .Values.inboxListener.deployment.extraVolumeMounts }}
+            {{- toYaml .Values.inboxListener.deployment.extraVolumeMounts | nindent 10 }}
           {{- end }}
         ports:
           - name: metrics

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -21,9 +21,17 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
+      {{- if .Values.siteController.deployment.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.siteController.deployment.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.siteController.deployment.initContainers }}
+      initContainers:
+{{ toYaml .Values.siteController.deployment.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: site-controller
-          image: us-central1-docker.pkg.dev/foxglove-images/images/site-controller:{{ .Chart.AppVersion }}
+          image: {{ .Values.siteController.deployment.image }}:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.siteController.deployment.resources.requests.cpu }}
@@ -42,6 +50,10 @@ spec:
             - secretRef:
                 name: foxglove-site-token
                 optional: true
+          {{- if .Values.siteController.deployment.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.siteController.deployment.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           env:
             - name: FOXGLOVE_API_URL
               value: {{ .Values.globals.foxgloveApiUrl }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -31,9 +31,16 @@ spec:
           secret:
             secretName: gcp-cloud-credential
             optional: true
+      {{- if .Values.streamService.deployment.extraVolumes }}
+        {{- toYaml .Values.streamService.deployment.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- if .Values.streamService.deployment.initContainers }}
+      initContainers:
+        {{- toYaml .Values.streamService.deployment.initContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: stream-service
-          image: us-central1-docker.pkg.dev/foxglove-images/images/stream-server:{{ .Chart.AppVersion }}
+          image: {{ .Values.streamService.deployment.image }}:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}
@@ -49,6 +56,9 @@ spec:
           volumeMounts:
             - mountPath: /secrets
               name: cloud-credentials
+          {{- if .Values.streamService.deployment.extraVolumeMounts }}
+            {{- toYaml .Values.streamService.deployment.extraVolumeMounts | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: cloud-credentials

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -51,7 +51,11 @@ ingress:
 
 inboxListener:
   deployment:
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener"
     replicas: 1
+    initContainers: []
+    extraVolumes: []
+    extraVolumeMounts: []
     resources:
       requests:
         cpu: 1000m
@@ -132,7 +136,11 @@ streamService:
   service:
     annotations: {}
   deployment:
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/stream-server"
     replicas: 1
+    initContainers: []
+    extraVolumes: []
+    extraVolumeMounts: []
     resources:
       requests:
         cpu: 1000m
@@ -161,6 +169,10 @@ siteController:
   service:
     annotations: {}
   deployment:
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/site-controller"
+    initContainers: []
+    extraVolumes: []
+    extraVolumeMounts: []
     resources:
       requests:
         cpu: 250m
@@ -181,6 +193,10 @@ garbageCollector:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   deployment:
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/garbage-collector"
+    initContainers: []
+    extraVolumes: []
+    extraVolumeMounts: []
     env: []
     nodeSelectors: {}
     serviceAccount:


### PR DESCRIPTION
### Changelog

edge-site: add support extra custom volumes, init containers and image names
primary-site: add support extra custom volumes, init containers and image names

### Docs

None

### Description
Add support for custom volumes and init containers in all Helm charts. Also move image names to a chart value. 

This should allow end users to specify custom credentials and workflows enabling more advanced usecases like adding a trusted certificate chain.

Fixes: FG-9734
