### PR TITLE
primary-site: default HTTP/HTTPS proxy egress to disabled

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.54"
+version: "0.0.55"
 
 appVersion: "b5ab5dc7bd5ef765d43830423ea4465d3bb016b1"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -19,9 +19,9 @@ globals:
     storageProvider: google_cloud
     bucketName: foxglove-inbox
   
+  ## Optionally used to configure http/https proxy egress
   proxy:
-  ## If you are running behind a proxy, otherwise set this to 'false'
-    enabled: true
+    enabled: false
     httpProxy: ""
     httpsProxy: ""
     noProxy: ""

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -19,7 +19,7 @@ globals:
     storageProvider: google_cloud
     bucketName: foxglove-inbox
   
-  ## Optionally used to configure http/https proxy egress
+  ## Configure an http/https egress proxy if your environment requires outgoing connections to be proxied. Set `enabled` to `true` and appropriate values for `httpProxy`, `httpsProxy` and `noProxy`.
   proxy:
     enabled: false
     httpProxy: ""


### PR DESCRIPTION
### Changelog
primary-site:
* fix: default HTTP/HTTPS proxy egress to disabled

### Docs
None

### Description
Default HTTP/HTTPS proxy egress to disabled.