### PR TITLE
add proxy support to garbage collector

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.56"
+version: "0.0.57"
 
 appVersion: "b5ab5dc7bd5ef765d43830423ea4465d3bb016b1"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -79,6 +79,14 @@ spec:
                   value: "true"
                 - name: PRIMARY_SITE_VERSION
                   value: "{{ .Chart.Version }}"
+                {{- if .Values.globals.proxy.enabled }}
+                - name: HTTP_PROXY
+                  value: {{ .Values.globals.proxy.httpProxy }}
+                - name: HTTPS_PROXY
+                  value: {{ .Values.globals.proxy.httpsProxy }}
+                - name: NO_PROXY
+                  value: {{ .Values.globals.proxy.noProxy }}
+                {{- end }}
                 {{- range $item := .Values.garbageCollector.deployment.env }}
                 - name: {{ $item.name }}
                   value: {{ $item.value | quote}}


### PR DESCRIPTION
### Changelog
Fix: Add HTTP proxy support to garbage collector

### Docs
None

### Description
Add HTTP proxying support to garbage collector cronjob.
