### PR TITLE
Update primary site to default to beta stream service

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.58"
+version: "0.0.59"
 
-appVersion: "1b4d4155a4c1efbc12450e870d32229815710078"
+appVersion: "a060d72e19ebc23a5af45b998809627923829e51"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -40,7 +40,9 @@ spec:
       {{- end }}
       containers:
         - name: stream-service
-          image: {{ .Values.streamService.deployment.image }}:{{ .Chart.AppVersion }}
+          ## If the betaOptOut flag is enabled, fall back to the legacy stream server image
+          {{- $image := ternary "legacyImage" "image" .Values.streamService.betaOptOut }}
+          image: {{ index .Values.streamService.deployment $image }}:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -133,10 +133,13 @@ inboxListener:
     pollingInterval: 30
 
 streamService:
+  # This chart defaults to a new version of the stream server. To disable this set the `betaOptOut` flag to true.
+  betaOptOut: false
   service:
     annotations: {}
   deployment:
-    image: "us-central1-docker.pkg.dev/foxglove-images/images/stream-server"
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/beta-stream-server"
+    legacyImage: "us-central1-docker.pkg.dev/foxglove-images/images/stream-server"
     replicas: 1
     initContainers: []
     extraVolumes: []


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

The chart now defaults to the new stream server image. There is a flag to opt out, however this will eventually be removed.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

Docs PR incoming.

### Description

This change updates the helm charts to default to the new version of the stream server. It also adds in an option that can be enabled to revert back to the old stream server.