### PR TITLE
Default to empty metrics namespace/subsystem

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -5,14 +5,6 @@ icon: https://foxglove.dev/images/logo-icon-round.png
 
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-#
-# Example versions:
-# 1.0.0-alpha.0
-# 1.0.0-alpha.1
-# 1.0.0
-version: "0.0.58"
+version: "0.0.59"
 
 appVersion: "1b4d4155a4c1efbc12450e870d32229815710078"

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -19,7 +19,8 @@ spec:
         format: "prometheus"
         targetValue: "2"
         url: "http://site-controller.{{.Release.Namespace}}.svc.cluster.local:6001/metrics"
-        valueLocation: "{{ with .Values.siteController.deployment.metrics.namespace }}{{ . }}{{else}}foxglove_data_platform{{ end }}_{{ with .Values.siteController.deployment.metrics.subsystem }}{{ . }}{{else}}site_controller{{ end }}_unleased_pending_import_count"
+        valueLocation: "
+        {{ with .Values.siteController.deployment.metrics.namespace }}{{ . }}_{{ end }}{{ with .Values.siteController.deployment.metrics.subsystem }}{{ . }}_{{ end }}unleased_pending_import_count"
 {{- else }}
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
### Changelog
Breaking change: Default to an empty metrics namespace/subsystem. To retain previous behavior set `siteController.deployment.metrics.namespace` to `foxglove_data_platform` and `siteController.deployment.metrics.subsystem` to `site_controller`.

### Docs
[Will need a corresponding docs PR ](https://github.com/foxglove/docs/pull/568)


### Description
Specifying a default metrics namespace and subsystem is a bit of an anti-pattern, and only the site-controller currently does it. This change will revert to empty strings, which is a breaking change without updating `values.yaml` if these metrics are used.

Fixes: FG-4667
