### PR TITLE
Release version v0.0.60

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.59"
+version: "0.0.60"
 
 appVersion: "a060d72e19ebc23a5af45b998809627923829e51"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -40,8 +40,8 @@ spec:
       {{- end }}
       containers:
         - name: stream-service
-          ## If the betaOptOut flag is enabled, fall back to the legacy stream server image
-          {{- $image := ternary "legacyImage" "image" .Values.streamService.betaOptOut }}
+          ## If the useLegacyImage flag is enabled, fall back to the legacy stream server image
+          {{- $image := ternary "legacyImage" "image" .Values.streamService.useLegacyImage }}
           image: {{ index .Values.streamService.deployment $image }}:{{ .Chart.AppVersion }}
           resources:
             requests:

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -133,8 +133,8 @@ inboxListener:
     pollingInterval: 30
 
 streamService:
-  # This chart defaults to a new version of the stream server. To disable this set the `betaOptOut` flag to true.
-  betaOptOut: false
+  # This chart defaults to a new version of the stream server. To revert to the legacy image, set the `useLegacyImage` flag to true.
+  useLegacyImage: false
   service:
     annotations: {}
   deployment:


### PR DESCRIPTION
Bumps the version to v0.0.60 and renames the opt-out flag to `useLegacyImage`.
