### PR TITLE
primary-site: bump version to v0.0.64

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.63"
+version: "0.0.64"
 
-appVersion: "b8966af424435eaaefac5e0d5bcbd00fabd04799"
+appVersion: "81e0bcbf53c7ae1bfb4f92e518cbd481bd8f187c"


### PR DESCRIPTION
### Changelog
- Fixed: Setting device name in object metadata when uploading to inbox now results in a recording associated with that device, rather than a deviceless recording.
- Changed: Buffered sequence node default changed from 32 to 0.
### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

