### PR TITLE
primary-site: remove legacy stream server, bump to 0.0.70

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.69"
+version: "0.0.70"
 
-appVersion: "965edfa6f44191c2fc60b947f25266fa39550bdd"
+appVersion: "1c99a0110bc6ce2e12d2bd6f6905df114ad6dc5d"

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -40,9 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: stream-service
-          ## If the useLegacyImage flag is enabled, fall back to the legacy stream server image
-          {{- $image := ternary "legacyImage" "image" .Values.streamService.useLegacyImage }}
-          image: {{ index .Values.streamService.deployment $image }}:{{ .Chart.AppVersion }}
+          image: {{ .Values.streamService.deployment.image }}:{{ .Chart.AppVersion }}
           resources:
             requests:
               cpu: {{ .Values.streamService.deployment.resources.requests.cpu }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -133,13 +133,10 @@ inboxListener:
     pollingInterval: 30
 
 streamService:
-  # This chart defaults to a new version of the stream server. To revert to the legacy image, set the `useLegacyImage` flag to true.
-  useLegacyImage: false
   service:
     annotations: {}
   deployment:
-    image: "us-central1-docker.pkg.dev/foxglove-images/images/beta-stream-server"
-    legacyImage: "us-central1-docker.pkg.dev/foxglove-images/images/stream-server"
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/stream-server"
     replicas: 1
     initContainers: []
     extraVolumes: []


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

- remove "useLegacyImage" option for stream server

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

None

### Description

Removes the "useLegacyImage" from the chart, since the legacy image is no longer deployed.
