### PR TITLE
To disable persistence functionality for edge sites

### DIFF
--- a/charts/edge-site/templates/statefulset.yaml
+++ b/charts/edge-site/templates/statefulset.yaml
@@ -23,12 +23,21 @@ spec:
       volumes:
         {{ if eq .Values.recordingStorage.provider "local" }}
         - name: storage-root
+          {{ if .Values.globals.persistence.enabled }}
           persistentVolumeClaim:
             claimName: "{{ .Values.edgeController.storageClaim }}"
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
+
         {{ end }}
         - name: index-root
+          {{ if .Values.globals.persistence.enabled }}
           persistentVolumeClaim:
             claimName: "{{ .Values.edgeController.indexClaim }}"
+          {{ else }}
+          emptyDir: {}
+          {{ end }}
         - name: cloud-credentials
           secret:
             secretName: gcp-cloud-credential

--- a/charts/edge-site/values.yaml
+++ b/charts/edge-site/values.yaml
@@ -12,6 +12,10 @@ globals:
   # The api endpoint the deployment will use as the control plane
   foxgloveApiUrl: https://api.foxglove.dev
 
+  # To enable/disable persistence for the edge controller.
+  persistence:
+    enabled: true
+
   aws:
     ## For example: us-east-1
     region: ""
@@ -32,6 +36,7 @@ globals:
 # Configuration for recording storage, defaults to the persistent volume configured by
 # `edgeController.storageClaim`
 recordingStorage:
+  enabled: false
   provider: "local"
   # If storing recordings on an S3-compatible service, set `provider` to "s3_compatible"
   # The service URL eg. https://my-minio-service.mycompany.com


### PR DESCRIPTION
### Changelog
In `edge-site` helmchar, have a functionality to enable/disable persistence. 

### Docs

Add `globals.persistence.enabled` flag to enable and disable persistence on `edge-site` deployment

### Description

Edge sites might not always need storage persistence; this feature will help in enabling no persistence.


![image](https://github.com/user-attachments/assets/fe839941-438a-468f-b234-451c990eb165)

