### PR TITLE
primary-site: update to version 0.0.71

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.70"
+version: "0.0.71"
 
-appVersion: "1c99a0110bc6ce2e12d2bd6f6905df114ad6dc5d"
+appVersion: "46429825def06943c29021a7366107499e10ab5a"

--- a/charts/primary-site/templates/deployments/_inbox-container.tpl
+++ b/charts/primary-site/templates/deployments/_inbox-container.tpl
@@ -39,7 +39,8 @@ template:
     {{- end }}
     containers:
       - name: inbox-listener
-        image: {{ .Values.inboxListener.deployment.image }}:{{ .Chart.AppVersion }}
+        {{- $image := ternary "legacyImage" "image" .Values.inboxListener.useLegacyImage }}
+        image: {{ index .Values.inboxListener.deployment $image }}:{{ .Chart.AppVersion }}
         resources:
           requests:
             cpu: {{ .Values.inboxListener.deployment.resources.requests.cpu }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -50,7 +50,11 @@ ingress:
     ##   secretName: ingress-tls-csi
 
 inboxListener:
+  # This chart defaults to a legacy version of the stream server. Set `useLegacyImage` to `false` to
+  # use the new image. This value will default to `false` in a future version.
+  useLegacyImage: true
   deployment:
+    legacyImage: "us-central1-docker.pkg.dev/foxglove-images/images/legacy-inbox-listener"
     image: "us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener"
     replicas: 1
     initContainers: []


### PR DESCRIPTION
### Changelog
None.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description
- Includes a template change to allow toggling to the new Rust inbox listener image. This flag is opt-in for this version. In a later version it will be switched to opt-out.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

### Manual testing
I checked that the templating produces the legacy inbox listener image with `helm template charts/primary-site`. 
I also deployed this release to my sandbox, the legacy inbox listener deploys as expected. with `useLegacyImage: false`, the rust inbox listener deploys as expected.


<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

