### PR TITLE
primary-site: add index-in-place strategy, bump to 0.0.74

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,10 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-<<<<<<< HEAD
 version: "0.0.74"
-=======
-version: "0.0.72-alpha.0"
->>>>>>> 3acec5e (fix indexer templating)
 
-appVersion: "68b2a1458609ef92263409a8e47a6eaa0ed9aea5"
+appVersion: "dcc5a9fa47127aef60715244ad19d8349c57d241"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,10 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
+<<<<<<< HEAD
 version: "0.0.74"
+=======
+version: "0.0.72-alpha.0"
+>>>>>>> 3acec5e (fix indexer templating)
 
 appVersion: "68b2a1458609ef92263409a8e47a6eaa0ed9aea5"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.73"
+version: "0.0.74"
 
 appVersion: "68b2a1458609ef92263409a8e47a6eaa0ed9aea5"

--- a/charts/primary-site/templates/_helpers.tpl
+++ b/charts/primary-site/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "primary-site.indexingStrategy" -}}
+{{- .Values.globals.indexingStrategy | default "split-files" -}}
+{{- end -}}

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -1,3 +1,5 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "split-files" }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -46,7 +48,7 @@ spec:
                     name: {{ $k }}
                 {{- end }}
               env:
-                {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
+                {{- with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
                 ## The lookup is required here. The pod may have access to GCP through other means, but
                 ## the credentials in this env var take precedence, even if it's empty. An empty variable
                 ## essentially blocks GCP access.
@@ -101,3 +103,4 @@ spec:
             {{ $key }}: {{ $value | quote }}
             {{- end }}
           {{- end}}
+{{- end }}

--- a/charts/primary-site/templates/deployments/inbox-listener.yaml
+++ b/charts/primary-site/templates/deployments/inbox-listener.yaml
@@ -1,3 +1,5 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "split-files" }}
 {{- if .Values.inboxListener.autoscaling.enabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
@@ -38,4 +40,5 @@ spec:
       maxUnavailable: 25%
     type: RollingUpdate
   {{ include "primary-site.inbox-container" . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/primary-site/templates/deployments/indexer.yaml
+++ b/charts/primary-site/templates/deployments/indexer.yaml
@@ -28,9 +28,13 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
-      {{- if .Values.indexer.deployment.extraVolumes }}
       volumes:
-        {{- toYaml .Values.indexer.deployment.extraVolumes | nindent 6 }}
+        - name: cloud-credentials
+          secret:
+            secretName: gcp-cloud-credential
+            optional: true
+      {{- if .Values.indexer.deployment.extraVolumes }}
+        {{- toYaml .Values.indexer.deployment.extraVolumes | nindent 8 }}
       {{- end }}
       {{- if .Values.indexer.deployment.nodeSelectors }}
       nodeSelector:
@@ -43,7 +47,7 @@ spec:
       {{- end}}
       {{- if .Values.indexer.deployment.initContainers }}
       initContainers:
-        {{- toYaml .Values.indexer.deployment.initContainers | nindent 6 }}
+        {{- toYaml .Values.indexer.deployment.initContainers | nindent 8 }}
       {{- end }}
       containers:
         - name: indexer
@@ -55,9 +59,11 @@ spec:
             limits:
               cpu: {{ .Values.indexer.deployment.resources.limits.cpu }}
               memory: {{ .Values.indexer.deployment.resources.limits.memory }}
-          {{- if .Values.indexer.deployment.extraVolumeMounts }}
           volumeMounts:
-            {{- toYaml .Values.indexer.deployment.extraVolumeMounts | nindent 10 }}
+            - mountPath: /secrets
+              name: cloud-credentials
+          {{- if .Values.indexer.deployment.extraVolumeMounts }}
+            {{- toYaml .Values.indexer.deployment.extraVolumeMounts | nindent 12 }}
           {{- end }}
           ports:
             - name: metrics
@@ -74,6 +80,13 @@ spec:
                 name: foxglove-site-token
                 optional: true
           env:
+            {{- with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
+            ## The lookup is required here. The pod may have access to GCP through other means, but
+            ## the credentials in this env var take precedence, even if it's empty. An empty variable
+            ## essentially blocks GCP access.
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /secrets/credentials.json
+            {{- end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
             {{- if .Values.globals.siteToken }}

--- a/charts/primary-site/templates/deployments/indexer.yaml
+++ b/charts/primary-site/templates/deployments/indexer.yaml
@@ -16,94 +16,106 @@ spec:
       maxSurge: 25%
       maxUnavailable: 25%
     type: RollingUpdate
-  metadata:
-    labels:
-      app: indexer
-      {{- range $key, $value := .Values.indexer.deployment.podLabels }}
-      {{ $key }}: {{ $value | quote }}
+  template:
+    metadata:
+      labels:
+        app: indexer
+        {{- range $key, $value := .Values.indexer.deployment.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      annotations:
+        {{- range $key, $value := .Values.indexer.deployment.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    spec:
+      {{- if .Values.indexer.deployment.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.indexer.deployment.extraVolumes | nindent 6 }}
       {{- end }}
-    annotations:
-      {{- range $key, $value := .Values.indexer.deployment.podAnnotations }}
-      {{ $key }}: {{ $value | quote }}
+      {{- if .Values.indexer.deployment.nodeSelectors }}
+      nodeSelector:
+        {{- range $key, $value := .Values.indexer.deployment.nodeSelectors }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- end}}
+      {{- if .Values.indexer.deployment.serviceAccount.enabled }}
+      serviceAccount: indexer
+      {{- end}}
+      {{- if .Values.indexer.deployment.initContainers }}
+      initContainers:
+        {{- toYaml .Values.indexer.deployment.initContainers | nindent 6 }}
       {{- end }}
-  spec:
-    {{- if .Values.indexer.deployment.nodeSelectors }}
-    nodeSelector:
-      {{- range $key, $value := .Values.indexer.deployment.nodeSelectors }}
-      {{ $key }}: {{ $value | quote }}
-      {{- end }}
-    {{- end}}
-    {{- if .Values.indexer.deployment.serviceAccount.enabled }}
-    serviceAccount: indexer
-    {{- end}}
-    {{- if .Values.indexer.deployment.initContainers }}
-    initContainers:
-      {{- toYaml .Values.indexer.deployment.initContainers | nindent 6 }}
-    {{- end }}
-    containers:
-      - name: indexer
-        image: {{ .Values.indexer.deployment.image }}:{{ .Chart.AppVersion }}
-        resources:
-          requests:
-            cpu: {{ .Values.indexer.deployment.resources.requests.cpu }}
-            memory: {{ .Values.indexer.deployment.resources.requests.memory }}
-          limits:
-            cpu: {{ .Values.indexer.deployment.resources.limits.cpu }}
-            memory: {{ .Values.indexer.deployment.resources.limits.memory }}
-        ports:
-          - name: metrics
-            containerPort: 6001
-        livenessProbe:
-          httpGet:
-            path: /liveness
-            port: 6002
-        envFrom:
-          - secretRef:
-              name: foxglove-site-token
-              optional: true
-        env:
-          - name: FOXGLOVE_API_URL
-            value: "{{ .Values.globals.foxgloveApiUrl }}"
-          {{- if .Values.globals.siteToken }}
-          - name: FOXGLOVE_SITE_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: foxglove-site
-                key: token
-                optional: false
+      containers:
+        - name: indexer
+          image: {{ .Values.indexer.deployment.image }}:{{ .Chart.AppVersion }}
+          resources:
+            requests:
+              cpu: {{ .Values.indexer.deployment.resources.requests.cpu }}
+              memory: {{ .Values.indexer.deployment.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.indexer.deployment.resources.limits.cpu }}
+              memory: {{ .Values.indexer.deployment.resources.limits.memory }}
+          {{- if .Values.indexer.deployment.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.indexer.deployment.extraVolumeMounts | nindent 10 }}
           {{- end }}
-          - name: STORAGE_PROVIDER
-            value: "{{ .Values.globals.indexInPlace.storageProvider }}"
-          - name: STORAGE_BUCKET_NAME
-            value: "{{ .Values.globals.indexInPlace.bucketName }}"
-          - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
-            value: "{{ .Values.globals.azure.storageAccountName }}"
-          - name: STORAGE_AZURE_SERVICE_URL
-            value: "{{ .Values.globals.azure.serviceUrl }}"
-          - name: AWS_REGION
-            value: "{{ .Values.globals.aws.region }}"
-          - name: AWS_SDK_LOAD_CONFIG
-            value: "true"
-          - name: LIVENESS_PORT
-            value: "6002"
-          - name: PROMETHEUS_PORT
-            value: "6001"
-          - name: PROMETHEUS_METRICS_NAMESPACE
-            value: "{{ .Values.indexer.deployment.metrics.namespace }}"
-          - name: PROMETHEUS_METRICS_SUBSYSTEM
-            value: "{{ .Values.indexer.deployment.metrics.subsystem }}"
-          - name: PRIMARY_SITE_VERSION
-            value: "{{ .Chart.Version }}"
-          {{- if .Values.globals.proxy.enabled }}
-          - name: HTTP_PROXY
-            value: {{ .Values.globals.proxy.httpProxy }}
-          - name: HTTPS_PROXY
-            value: {{ .Values.globals.proxy.httpsProxy }}
-          - name: NO_PROXY
-            value: {{ .Values.globals.proxy.noProxy }}
-          {{- end }}
-          {{- range $item := .Values.indexer.deployment.env }}
-          - name: {{ $item.name }}
-            value: {{ $item.value | quote}}
-          {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 6001
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 6002
+          envFrom:
+            - secretRef:
+                name: cloud-credentials
+                optional: true
+            - secretRef:
+                name: foxglove-site-token
+                optional: true
+          env:
+            - name: FOXGLOVE_API_URL
+              value: "{{ .Values.globals.foxgloveApiUrl }}"
+            {{- if .Values.globals.siteToken }}
+            - name: FOXGLOVE_SITE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: foxglove-site
+                  key: token
+                  optional: false
+            {{- end }}
+            - name: STORAGE_PROVIDER
+              value: "{{ .Values.globals.indexInPlace.storageProvider }}"
+            - name: STORAGE_BUCKET_NAME
+              value: "{{ .Values.globals.indexInPlace.bucketName }}"
+            - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
+              value: "{{ .Values.globals.azure.storageAccountName }}"
+            - name: STORAGE_AZURE_SERVICE_URL
+              value: "{{ .Values.globals.azure.serviceUrl }}"
+            - name: AWS_REGION
+              value: "{{ .Values.globals.aws.region }}"
+            - name: AWS_SDK_LOAD_CONFIG
+              value: "true"
+            - name: LIVENESS_PORT
+              value: "6002"
+            - name: PROMETHEUS_PORT
+              value: "6001"
+            - name: PROMETHEUS_METRICS_NAMESPACE
+              value: "{{ .Values.indexer.deployment.metrics.namespace }}"
+            - name: PROMETHEUS_METRICS_SUBSYSTEM
+              value: "{{ .Values.indexer.deployment.metrics.subsystem }}"
+            - name: PRIMARY_SITE_VERSION
+              value: "{{ .Chart.Version }}"
+            {{- if .Values.globals.proxy.enabled }}
+            - name: HTTP_PROXY
+              value: {{ .Values.globals.proxy.httpProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.globals.proxy.httpsProxy }}
+            - name: NO_PROXY
+              value: {{ .Values.globals.proxy.noProxy }}
+            {{- end }}
+            {{- range $item := .Values.indexer.deployment.env }}
+            - name: {{ $item.name }}
+              value: {{ $item.value | quote}}
+            {{- end }}
 {{- end }}

--- a/charts/primary-site/templates/deployments/indexer.yaml
+++ b/charts/primary-site/templates/deployments/indexer.yaml
@@ -1,0 +1,109 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "index-in-place" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: indexer
+  labels:
+    app: indexer
+spec:
+  replicas: {{ .Values.indexer.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: indexer
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  metadata:
+    labels:
+      app: indexer
+      {{- range $key, $value := .Values.indexer.deployment.podLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    annotations:
+      {{- range $key, $value := .Values.indexer.deployment.podAnnotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+  spec:
+    {{- if .Values.indexer.deployment.nodeSelectors }}
+    nodeSelector:
+      {{- range $key, $value := .Values.indexer.deployment.nodeSelectors }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end}}
+    {{- if .Values.indexer.deployment.serviceAccount.enabled }}
+    serviceAccount: indexer
+    {{- end}}
+    {{- if .Values.indexer.deployment.initContainers }}
+    initContainers:
+      {{- toYaml .Values.indexer.deployment.initContainers | nindent 6 }}
+    {{- end }}
+    containers:
+      - name: indexer
+        image: {{ .Values.indexer.deployment.image }}:{{ .Chart.AppVersion }}
+        resources:
+          requests:
+            cpu: {{ .Values.indexer.deployment.resources.requests.cpu }}
+            memory: {{ .Values.indexer.deployment.resources.requests.memory }}
+          limits:
+            cpu: {{ .Values.indexer.deployment.resources.limits.cpu }}
+            memory: {{ .Values.indexer.deployment.resources.limits.memory }}
+        ports:
+          - name: metrics
+            containerPort: 6001
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 6002
+        envFrom:
+          - secretRef:
+              name: foxglove-site-token
+              optional: true
+        env:
+          - name: FOXGLOVE_API_URL
+            value: "{{ .Values.globals.foxgloveApiUrl }}"
+          {{- if .Values.globals.siteToken }}
+          - name: FOXGLOVE_SITE_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: foxglove-site
+                key: token
+                optional: false
+          {{- end }}
+          - name: STORAGE_PROVIDER
+            value: "{{ .Values.globals.indexInPlace.storageProvider }}"
+          - name: STORAGE_BUCKET_NAME
+            value: "{{ .Values.globals.indexInPlace.bucketName }}"
+          - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
+            value: "{{ .Values.globals.azure.storageAccountName }}"
+          - name: STORAGE_AZURE_SERVICE_URL
+            value: "{{ .Values.globals.azure.serviceUrl }}"
+          - name: AWS_REGION
+            value: "{{ .Values.globals.aws.region }}"
+          - name: AWS_SDK_LOAD_CONFIG
+            value: "true"
+          - name: LIVENESS_PORT
+            value: "6002"
+          - name: PROMETHEUS_PORT
+            value: "6001"
+          - name: PROMETHEUS_METRICS_NAMESPACE
+            value: "{{ .Values.indexer.deployment.metrics.namespace }}"
+          - name: PROMETHEUS_METRICS_SUBSYSTEM
+            value: "{{ .Values.indexer.deployment.metrics.subsystem }}"
+          - name: PRIMARY_SITE_VERSION
+            value: "{{ .Chart.Version }}"
+          {{- if .Values.globals.proxy.enabled }}
+          - name: HTTP_PROXY
+            value: {{ .Values.globals.proxy.httpProxy }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.globals.proxy.httpsProxy }}
+          - name: NO_PROXY
+            value: {{ .Values.globals.proxy.noProxy }}
+          {{- end }}
+          {{- range $item := .Values.indexer.deployment.env }}
+          - name: {{ $item.name }}
+            value: {{ $item.value | quote}}
+          {{- end }}
+{{- end }}

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -1,3 +1,5 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "split-files" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -90,3 +92,4 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end}}
+{{- end }}

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -1,3 +1,4 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -71,7 +72,7 @@ spec:
                 name: {{ $k }}
             {{- end }}
           env:
-            {{ with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
+            {{- with lookup "v1" "Secret" .Release.Namespace "gcp-cloud-credential" }}
             ## The lookup is required here. The pod may have access to GCP through other means, but
             ## the credentials in this env var take precedence, even if it's empty. An empty variable
             ## essentially blocks GCP access.
@@ -94,12 +95,17 @@ spec:
               value: "{{ .Values.globals.aws.region }}"
             - name: AWS_SDK_LOAD_CONFIG
               value: "true"
+            {{- if eq $indexingStrategy "split-files" }}
             - name: LAKE_STORAGE_PROVIDER
               value: "{{ .Values.globals.lake.storageProvider }}"
             - name: INBOX_STORAGE_PROVIDER
               value: "{{ .Values.globals.inbox.storageProvider }}"
             - name: STORAGE_INBOX_BUCKET_NAME
               value: "{{ .Values.globals.inbox.bucketName }}"
+            {{- else if eq $indexingStrategy "index-in-place" }}
+            - name: LAKE_STORAGE_PROVIDER
+              value: "{{ .Values.globals.indexInPlace.storageProvider }}"
+            {{- end }}
             - name: STORAGE_AZURE_STORAGE_ACCOUNT_NAME
               value: "{{ .Values.globals.azure.storageAccountName }}"
             - name: STORAGE_AZURE_SERVICE_URL

--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -95,6 +95,8 @@ spec:
               value: "{{ .Values.globals.aws.region }}"
             - name: AWS_SDK_LOAD_CONFIG
               value: "true"
+            - name: SITE_INDEXING_STRATEGY
+              value: "{{ $indexingStrategy }}"
             {{- if eq $indexingStrategy "split-files" }}
             - name: LAKE_STORAGE_PROVIDER
               value: "{{ .Values.globals.lake.storageProvider }}"

--- a/charts/primary-site/templates/serviceaccounts/garbage-collector.yaml
+++ b/charts/primary-site/templates/serviceaccounts/garbage-collector.yaml
@@ -1,3 +1,5 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "split-files" }}
 {{- with .Values.garbageCollector.deployment.serviceAccount }}
 {{- if .enabled }}
 apiVersion: v1
@@ -8,5 +10,6 @@ metadata:
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/primary-site/templates/serviceaccounts/indexer.yaml
+++ b/charts/primary-site/templates/serviceaccounts/indexer.yaml
@@ -1,11 +1,11 @@
 {{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
-{{- if eq $indexingStrategy "split-files" }}
-{{- with .Values.inboxListener.deployment.serviceAccount }}
+{{- if eq $indexingStrategy "index-in-place" }}
+{{- with .Values.indexer.deployment.serviceAccount }}
 {{- if .enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: inbox-listener
+  name: indexer
   annotations:
     {{- range $key, $value := .annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/charts/primary-site/templates/services/site-controller.yaml
+++ b/charts/primary-site/templates/services/site-controller.yaml
@@ -1,3 +1,5 @@
+{{- $indexingStrategy := include "primary-site.indexingStrategy" . }}
+{{- if eq $indexingStrategy "split-files" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +17,4 @@ spec:
       targetPort: 6001
   selector:
     app: site-controller
+{{- end }}

--- a/charts/primary-site/values.schema.json
+++ b/charts/primary-site/values.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "objectStore": {
+      "type": "object",
+      "properties": {
+        "bucketName": {
+          "type": "string"
+        },
+        "storageProvider": {
+          "type": "string",
+          "enum": [
+            "aws",
+            "azure",
+            "google_cloud",
+            "s3_compatible"
+          ]
+        }
+      },
+      "requiredProperties": [
+        "bucketName",
+        "storageProvider"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "globals": {
+      "type": "object",
+      "properties": {
+        "foxgloveApiUrl": {
+          "type": "string"
+        },
+        "indexingStrategy": {
+          "type": "string",
+          "enum": [
+            "index-in-place",
+            "split-files"
+          ]
+        },
+        "lake": {
+          "$ref": "#/definitions/objectStore"
+        },
+        "inbox": {
+          "$ref": "#/definitions/objectStore"
+        },
+        "indexInPlace": {
+          "$ref": "#/definitions/objectStore"
+        }
+      },
+      "requiredProperties": [
+        "foxgloveApiUrl"
+      ]
+    }
+  },
+  "requiredProperties": [
+    "globals"
+  ]
+}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -208,6 +208,7 @@ streamService:
       ## annotations:
       ##   eks.amazonaws.com/role-arn: arn:aws:iam::xxxxxxxxxxxx:role/foxglove-stream-service-sa-role
 
+# The site-controller is only deployed if `indexingStrategy` is `split-files`.
 siteController:
   service:
     annotations: {}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -9,16 +9,26 @@ globals:
 
   foxgloveApiUrl: https://api.foxglove.dev
 
+  ## Supported indexingStrategy values are: `split-files` and `index-in-place`.
+  ## If none is provided, `split-files` is the default.
+  indexingStrategy: split-files
+
   ## Supported storageProvider values are: `google_cloud`, `aws`, `azure`, or `s3_compatible`.
   ## If `azure` is used, then the `@azure.storageAccountName` and `@azure.serviceUrl` values
   ## are required. If `aws` is used, then the `@aws.region` value is required.
+  ##
+  ## The `lake` and `inbox` configuration are required for the `split-files` indexing strategy.
+  ## The `indexInPlace` configuration is required for the `index-in-place` indexing strategy.
   lake:
     storageProvider: google_cloud
     bucketName: foxglove-lake
   inbox:
     storageProvider: google_cloud
     bucketName: foxglove-inbox
-  
+  indexInPlace:
+    storageProvider: google_cloud
+    bucketName: foxglove-index-in-place
+
   ## Configure an http/https egress proxy if your environment requires outgoing connections to be proxied. Set `enabled` to `true` and appropriate values for `httpProxy`, `httpsProxy` and `noProxy`.
   proxy:
     enabled: false
@@ -49,6 +59,7 @@ ingress:
     ##   - www.example.com
     ##   secretName: ingress-tls-csi
 
+# The inbox listener is only deployed if `indexingStrategy` is `split-files`.
 inboxListener:
   # The inbox listener image was recently rewritten. Set `useLegacyImage` to `false` to
   # revert to the legacy version. This option will be removed in a future chart version.
@@ -136,6 +147,34 @@ inboxListener:
     # how often to poll the autoscaling metric in seconds, provided as an integer. this is a safe default.
     pollingInterval: 30
 
+# The indexer is only deployed if `indexingStrategy` is `index-in-place`.
+indexer:
+  service:
+    annotations: {}
+  deployment:
+    image: "us-central1-docker.pkg.dev/foxglove-images/images/indexer"
+    replicas: 1
+    initContainers: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 2Gi
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+    podLabels: {}
+    podAnnotations: {}
+    nodeSelectors: {}
+    metrics:
+      namespace: ""
+      subsystem: ""
+    env: []
+    serviceAccount:
+      enabled: false
+      annotations: {}
+
 streamService:
   service:
     annotations: {}
@@ -192,6 +231,7 @@ siteController:
       subsystem: ""
     env: []
 
+# The garbage collector is only deployed if `indexingStrategy` is `split-files`.
 garbageCollector:
   schedule: "*/10 * * * *" # every 10 minutes
   failedJobsHistoryLimit: 1


### PR DESCRIPTION
### Changelog
- Add support for index-in-place primary sites
- stream server: fixed a bug in the stream server where start and end times before the unix epoch would result in a 500 internal server error.

### Docs
None

### Description
Adds `indexingStrategy` and `indexInPlace.storageProvider`/`.bucketName` global values, and the new indexer service. Various templates are toggled using the `indexingStrategy` enum.