### PR TITLE
update to latest data-plaform, default to rust inbox listener

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.71"
+version: "0.0.72"
 
-appVersion: "46429825def06943c29021a7366107499e10ab5a"
+appVersion: "476c134b9f1ae4a33f446d7f28ba4b583026b70a"

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -50,9 +50,9 @@ ingress:
     ##   secretName: ingress-tls-csi
 
 inboxListener:
-  # This chart defaults to a legacy version of the stream server. Set `useLegacyImage` to `false` to
-  # use the new image. This value will default to `false` in a future version.
-  useLegacyImage: true
+  # The inbox listener image was recently rewritten. Set `useLegacyImage` to `false` to
+  # revert to the legacy version. This option will be removed in a future chart version.
+  useLegacyImage: false
   deployment:
     legacyImage: "us-central1-docker.pkg.dev/foxglove-images/images/legacy-inbox-listener"
     image: "us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener"


### PR DESCRIPTION
### Changelog
- `stream-server`: Fix ROS1 array slicing skipping past end of array (foxglove/data-platform#1987)
- `stream-server`: handle bounds before unix timestamp (foxglove/data-platform#1989)
- `stream-server`: Ignore empty requested topics filter (foxglove/data-platform#1998)
- `stream-server`: Fix ROS1 local message name resolution (foxglove/data-platform#2006)
- `stream-server`: Enable stream-by-message path for `omgidl` schema encoding   (foxglove/data-platform#2012)
- `primary-site`: default to Rust inbox listener image.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

Updates to the latest data-platform version, which includes all bug fixes for message-path streaming. Also defaults to the rust inbox listener image.

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

