### PR TITLE
primary-site: Plumb globals.siteToken to stream server

### DIFF
--- a/charts/primary-site/templates/deployments/stream-service.yaml
+++ b/charts/primary-site/templates/deployments/stream-service.yaml
@@ -89,6 +89,14 @@ spec:
             {{- end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
+            {{- if .Values.globals.siteToken }}
+            - name: FOXGLOVE_SITE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: foxglove-site
+                  key: token
+                  optional: false
+            {{- end }}
             - name: PORT
               value: "8080"
             - name: AWS_REGION


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
If the user follows the installation guide's [instructions for setting up the site token secret](https://docs.foxglove.dev/docs/data/primary-sites/installation#create-secret-with-site-token), it will be plumbed down through [the `envFrom[].secretRef` spec](https://github.com/foxglove/helm-charts/blob/d1409d3c333d5bfc9114b55c7a8facff0430e220/charts/primary-site/templates/deployments/stream-service.yaml#L67-L69).

However, we also have an undocumented `Values.global.siteToken` which can be used to embed the literal site token directly into the helm chart. This is [plumbed for other deployments](https://github.com/foxglove/helm-charts/blob/d1409d3c333d5bfc9114b55c7a8facff0430e220/charts/primary-site/templates/deployments/site-controller.yaml#L70-L76), but not the stream server. This change makes the stream server consistent with other deployments in this respect.