### PR TITLE
primary-site: remove legacy inbox listener

### DIFF
--- a/charts/primary-site/templates/deployments/_inbox-container.tpl
+++ b/charts/primary-site/templates/deployments/_inbox-container.tpl
@@ -39,8 +39,7 @@ template:
     {{- end }}
     containers:
       - name: inbox-listener
-        {{- $image := ternary "legacyImage" "image" .Values.inboxListener.useLegacyImage }}
-        image: {{ index .Values.inboxListener.deployment $image }}:{{ .Chart.AppVersion }}
+        image: {{ .Values.inboxListener.deployment.image }}:{{ .Chart.AppVersion }}
         resources:
           requests:
             cpu: {{ .Values.inboxListener.deployment.resources.requests.cpu }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -61,11 +61,7 @@ ingress:
 
 # The inbox listener is only deployed if `indexingStrategy` is `split-files`.
 inboxListener:
-  # The inbox listener image was recently rewritten. Set `useLegacyImage` to `false` to
-  # revert to the legacy version. This option will be removed in a future chart version.
-  useLegacyImage: false
   deployment:
-    legacyImage: "us-central1-docker.pkg.dev/foxglove-images/images/legacy-inbox-listener"
     image: "us-central1-docker.pkg.dev/foxglove-images/images/inbox-listener"
     replicas: 1
     initContainers: []


### PR DESCRIPTION
### Changelog

- Removed: the inbox listener `useLegacyImage` configuraiton value has been removed. The legacy image is no longer available.
### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

