### PR TITLE
add service account properly

### DIFF
--- a/charts/primary-site/templates/serviceaccounts/query-service.yaml
+++ b/charts/primary-site/templates/serviceaccounts/query-service.yaml
@@ -1,11 +1,11 @@
 {{- $values :=  include "primary-site.mergedQueryServiceValues" . | fromYaml -}}
-{{- if .enabled }}
+{{- if $values.deployment.serviceAccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: query-service
   annotations:
-    {{- range $key, $value := $values.annotations }}
+    {{- range $key, $value := $values.deployment.serviceAccount.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
### Changelog
- primary site: fixed a bug introduced in v0.0.76 where the query service service account object not be created if enabled.
### Docs

None.
### Description

it looks like when renaming the stream service to query service, I didn't properly namespace the values used in the query-service serviceaccount template.

### Testing
- [x] rendered template using values that include a service account, verify that the required service account + annotations are created.
<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->
Fixes: FIRE-159

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

