### PR TITLE
Increase default inbox memory requests and limits to 8Gi

### DIFF
--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -74,10 +74,10 @@ inboxListener:
     resources:
       requests:
         cpu: 1000m
-        memory: 4Gi
+        memory: 8Gi
       limits:
         cpu: 1000m
-        memory: 4Gi
+        memory: 8Gi
     podLabels: {}
     podAnnotations: {}
     nodeSelectors: {}


### PR DESCRIPTION
### Changelog
Change default memory request/limit for inbox-listener to 8Gi

### Docs
None

### Description
8Gi is a more reasonable production default.
