### PR TITLE
primary-site: 0.0.103

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.102"
+version: "0.0.103"
 
-appVersion: "e7d45e2df04f772bbf527699d354271c34a75f7d"
+appVersion: "2a0f890e28706f8b57e91bf72f95fa537236a148"


### PR DESCRIPTION
### Added

- Exposed the object store read timeout via the `OBJECT_STORE_READ_TIMEOUT_SECONDS` variable

### Fixed

- Fixed the `AWS_COPY_PART_SIZE_BYTES` variable, which was documented but not previously applied to S3 multipart copies; the default part size now returns to 100 MiB from 5 GiB

Bumps `appVersion` to data-platform [`2a0f890`](https://github.com/foxglove/data-platform/commit/2a0f890e28706f8b57e91bf72f95fa537236a148).