### PR TITLE
remote-data-loader v0.0.7

### DIFF
--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -11,6 +11,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.6"
+version: "0.0.7"
 
-appVersion: "fc13ea1f96028813d5c8aeded2a222b3d9fd1503"
+appVersion: "cd6d7506e4eae7ec730c1de75a512efba14fccf6"

--- a/charts/remote-data-loader/templates/deployment.yaml
+++ b/charts/remote-data-loader/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- $deployment := .Values.remoteDataLoader.deployment -}}
 {{- $cache := .Values.globals.cache -}}
+{{- $manifestCache := .Values.globals.manifestCache -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -122,6 +123,14 @@ spec:
             {{- if .Values.globals.allowHttpSources }}
             - name: ALLOW_HTTP_SOURCES
               value: "true"
+            {{- end }}
+            {{- if and $manifestCache $manifestCache.ttlMs }}
+            - name: MANIFEST_CACHE_TTL_MS
+              value: "{{ $manifestCache.ttlMs }}"
+            {{- if $manifestCache.maxCapacity }}
+            - name: MANIFEST_CACHE_MAX_CAPACITY
+              value: "{{ $manifestCache.maxCapacity }}"
+            {{- end }}
             {{- end }}
             {{- if $cache.enabled }}
             - name: REQUEST_CACHE_STORAGE_PROVIDER

--- a/charts/remote-data-loader/values.schema.json
+++ b/charts/remote-data-loader/values.schema.json
@@ -50,6 +50,20 @@
         "allowHttpSources": {
           "type": "boolean"
         },
+        "manifestCache": {
+          "type": "object",
+          "properties": {
+            "ttlMs": {
+              "type": "number",
+              "description": "Cache successful manifest responses for this many milliseconds. 0 disables manifest caching. Must be <= 30000."
+            },
+            "maxCapacity": {
+              "type": "number",
+              "description": "Maximum number of manifest entries to cache. Must be > 0."
+            }
+          },
+          "additionalProperties": false
+        },
         "cache": {
           "type": "object",
           "properties": {

--- a/charts/remote-data-loader/values.yaml
+++ b/charts/remote-data-loader/values.yaml
@@ -34,6 +34,14 @@ globals:
   # Set to true to allow connections to the backend using HTTP.
   allowHttpSources: false
 
+  # In-memory cache for manifest responses. Set ttlMs > 0 to enable.
+  manifestCache:
+    # Cache successful manifest responses for this many milliseconds. 0 disables
+    # manifest caching. Must be <= 30000.
+    ttlMs: 0
+    # Maximum number of manifest entries to cache. Must be > 0.
+    maxCapacity: 1024
+
   # Bucket used by the remote data loader to cache and speed up queries.
   cache:
     enabled: false


### PR DESCRIPTION
### Changelog

- `remote-data-loader`: Added optional in-memory TTL cache for manifest responses. Set `globals.manifestCache.ttlMs` > 0 (max 30000) to enable. You can also optionally tune `globals.manifestCache.maxCapacity` (default 1024).
- `remote-data-loader`: improve error messaging when an HTTP url is supplied and `ALLOW_HTTP_SOURCES` is unset or false.

### Docs

None

### Description

Bumps the `remote-data-loader` chart.