### PR TITLE
primary-site: 0.0.104

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.103"
+version: "0.0.104"
 
-appVersion: "2a0f890e28706f8b57e91bf72f95fa537236a148"
+appVersion: "b0b04cb399ff381da080371fc0aecff768edd423"


### PR DESCRIPTION
Bump primary-site chart to `0.0.104`, pointing `appVersion` at the latest `data-platform` main commit (`b0b04cb`).

The app change in this build adds environment variables to set and override the `nofile` (open file descriptor) limits on the data-platform containers. This is needed for Fargate, where the limits can't be set via the usual mechanisms, and is a no-op for other cloud deployments that already get sane defaults.

- `version`: 0.0.103 → 0.0.104
- `appVersion`: 2a0f890e → b0b04cb399ff381da080371fc0aecff768edd423
