### PR TITLE
primary-site: 0.0.105

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.104"
+version: "0.0.105"
 
-appVersion: "b0b04cb399ff381da080371fc0aecff768edd423"
+appVersion: "38838a2cba29457b2cf80975557d54741305210b"

--- a/charts/primary-site/templates/cronjobs/garbage-collector.yaml
+++ b/charts/primary-site/templates/cronjobs/garbage-collector.yaml
@@ -78,6 +78,10 @@ spec:
                 {{ end }}
                 - name: FOXGLOVE_API_URL
                   value: "{{ .Values.globals.foxgloveApiUrl }}"
+                {{- if .Values.globals.maxOpenFiles }}
+                - name: MAX_OPEN_FILES
+                  value: {{ .Values.globals.maxOpenFiles | quote }}
+                {{- end }}
                 {{- if .Values.globals.siteToken }}
                 - name: FOXGLOVE_SITE_TOKEN
                   valueFrom:

--- a/charts/primary-site/templates/deployments/_inbox-container.tpl
+++ b/charts/primary-site/templates/deployments/_inbox-container.tpl
@@ -98,6 +98,10 @@ template:
           {{ end }}
           - name: FOXGLOVE_API_URL
             value: "{{ .Values.globals.foxgloveApiUrl }}"
+          {{- if .Values.globals.maxOpenFiles }}
+          - name: MAX_OPEN_FILES
+            value: {{ .Values.globals.maxOpenFiles | quote }}
+          {{- end }}
           {{- if .Values.globals.siteToken }}
           - name: FOXGLOVE_SITE_TOKEN
             valueFrom:

--- a/charts/primary-site/templates/deployments/indexer.yaml
+++ b/charts/primary-site/templates/deployments/indexer.yaml
@@ -89,6 +89,10 @@ spec:
             {{- end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
+            {{- if .Values.globals.maxOpenFiles }}
+            - name: MAX_OPEN_FILES
+              value: {{ .Values.globals.maxOpenFiles | quote }}
+            {{- end }}
             {{- if .Values.globals.siteToken }}
             - name: FOXGLOVE_SITE_TOKEN
               valueFrom:

--- a/charts/primary-site/templates/deployments/query-server.yaml
+++ b/charts/primary-site/templates/deployments/query-server.yaml
@@ -101,6 +101,10 @@ spec:
             {{- end }}
             - name: FOXGLOVE_API_URL
               value: "{{ .Values.globals.foxgloveApiUrl }}"
+            {{- if .Values.globals.maxOpenFiles }}
+            - name: MAX_OPEN_FILES
+              value: {{ .Values.globals.maxOpenFiles | quote }}
+            {{- end }}
             {{- if .Values.globals.siteToken }}
             - name: FOXGLOVE_SITE_TOKEN
               valueFrom:
@@ -138,6 +142,22 @@ spec:
               value: "{{ $values.deployment.metrics.subsystem }}"
             - name: PRIMARY_SITE_VERSION
               value: "{{ .Chart.Version }}"
+            ## Emitted before deployment.env so a target can also override either by
+            ## setting the same variable in queryService.deployment.env (last value wins).
+            {{- if $values.deployment.topicExec.partitionCount }}
+            - name: TOPIC_EXEC_PARTITION_COUNT
+              value: {{ $values.deployment.topicExec.partitionCount | quote }}
+            {{- else }}
+            ## Default the partition count to the CPU limit rounded up to whole cores.
+            - name: TOPIC_EXEC_PARTITION_COUNT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: query-service
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            - name: TOPIC_EXEC_BUFFERED_OBJECT_LIMIT
+              value: {{ $values.deployment.topicExec.bufferedObjectLimit | quote }}
             {{- range $item := $values.deployment.env }}
             - name: {{ $item.name }}
               value: {{ $item.value | quote}}

--- a/charts/primary-site/templates/deployments/site-controller.yaml
+++ b/charts/primary-site/templates/deployments/site-controller.yaml
@@ -69,6 +69,10 @@ spec:
           env:
             - name: FOXGLOVE_API_URL
               value: {{ .Values.globals.foxgloveApiUrl }}
+            {{- if .Values.globals.maxOpenFiles }}
+            - name: MAX_OPEN_FILES
+              value: {{ .Values.globals.maxOpenFiles | quote }}
+            {{- end }}
             {{- if .Values.globals.proxy.enabled }}
             - name: HTTP_PROXY
               value: {{ .Values.globals.proxy.httpProxy }}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -33,6 +33,11 @@ globals:
   ## Publish metrics from the primary site to Foxglove
   publishSiteMetrics: true
 
+  ## Raise the open-file (RLIMIT_NOFILE) soft limit on Foxglove pods that support it,
+  ## via the MAX_OPEN_FILES environment variable. Clamped to the container's hard limit.
+  ## Set to empty to leave the platform default untouched.
+  maxOpenFiles: 65535
+
   ## Configure an http/https egress proxy if your environment requires outgoing connections to be proxied. Set `enabled` to `true` and appropriate values for `httpProxy`, `httpsProxy` and `noProxy`.
   proxy:
     enabled: false
@@ -193,14 +198,20 @@ queryService:
         cpu: 1000m
         memory: 2Gi
       limits:
-        cpu: 1000m
-        memory: 2Gi
+        cpu: 4000m
+        memory: 8Gi
     podLabels: {}
     podAnnotations: {}
     nodeSelectors: {}
     metrics:
       namespace: ""
       subsystem: ""
+    topicExec:
+      ## Number of partitions a topic's files are read across in parallel.
+      ## Defaults to the CPU limit rounded up to whole cores when left empty.
+      partitionCount: ""
+      ## Max concurrent object reads buffered per partition.
+      bufferedObjectLimit: 8
     env: []
     serviceAccount:
       enabled: false


### PR DESCRIPTION
### Changelog

- Default `MAX_OPEN_FILES` to 65535
- Add support for multi-threaded message scanning
- Changed default query service CPU limits from 1 to 4 and memory limits from 2Gi to 8Gi
- Improve message scanning performance for search
