### PR TITLE
remote-data-loader v0.0.8

### DIFF
--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -11,6 +11,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.7"
+version: "0.0.8"
 
-appVersion: "cd6d7506e4eae7ec730c1de75a512efba14fccf6"
+appVersion: "3c01fa5a77feaa722a9c06ba39e26a66aedf37d4"


### PR DESCRIPTION
### Changelog

- `remote-data-loader` now supports forwarding error messages with the `x-foxglove-error-message` header

### Docs

None

### Description

Bumps the `remote-data-loader` chart to `3c01fa5a77feaa722a9c06ba39e26a66aedf37d4`.

<details><summary>extra context from agent</summary>

- Only `Chart.yaml` changed (`version` 0.0.7 → 0.0.8, `appVersion` bumped); no new env vars were added in this range, so `values.yaml`/`deployment.yaml`/schema were untouched.
- Five commits in this range touch the RDL path; the two above are user-facing. The other three are non-user-facing: Alpine base-image bump 3.24.0 → 3.24.1 (#3134), a `MAX_OPEN_FILES` rlimit tweak (#3070), and Azure dev deploy config (#3079).
- Checked re: CVE-2026-45447 (OpenSSL PKCS#7 use-after-free): not applicable. The RDL binary links rustls, not OpenSSL — `cargo tree -p remote-data-loader -i openssl-sys` returns no match even under `--all-features --target all`, at both the new and prior appVersions. OpenSSL only ever entered the workspace lockfile via sibling crates (`agent` via livekit/reqwest 0.11, `minio` dev-deps), never the loader.
</details>