### PR TITLE
remote-data-loader v0.0.9

### DIFF
--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -11,6 +11,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.8"
+version: "0.0.9"
 
-appVersion: "3c01fa5a77feaa722a9c06ba39e26a66aedf37d4"
+appVersion: "870efc318a2068fb274557b2e47389069e8c5a7d"


### PR DESCRIPTION
### Changelog

- `remote-data-loader` lookback now downloads fewer files
- `remote-data-loader` login page opens the identity provider in a popup instead of a new tab
- Services now use hickory dns

### Docs

None

### Description

Bumps the `remote-data-loader` chart to `870efc318a2068fb274557b2e47389069e8c5a7d`.

<details><summary>extra context from agent</summary>

- Only `Chart.yaml` changed (`version` 0.0.8 → 0.0.9, `appVersion` bumped). Env var reads across `rust/remote-data-loader`, `rust/query-engine`, and `common` are identical at both commits, so `values.yaml`, `values.schema.json`, and the templates were untouched.
- Three user-facing commits in this range:
  - Reduce data downloaded for RDL lookback (#3362) — lookback and playback are now separate stages; lookback stops once each topic has its newest message instead of pulling the newest from every overlapping source, and fetches run concurrently across topics. Previously every streamed source overlapping the lookback window was added to the merge node on every seek.
  - Open remote data loader auth window as a centered popup (#3491) — template-only change so the user's original tab isn't swapped out when the IdP window closes.
  - Use a shared caching DNS resolver for reqwest clients (#3499) — process-wide hickory resolver with caching and in-flight dedupe, fixing `dns error` under high load.
- Other commits touching `rust/` in this range are non-user-facing for the loader: dependency bumps (`base64`, `ulid`, `quinn-proto`, rust base image), stream-handler trace fields (#3483, #3472), and ML/column-store/query-engine work outside the loader's path.
</details>
