### PR TITLE
primary-site: 0.0.106

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.105"
+version: "0.0.106"
 
-appVersion: "38838a2cba29457b2cf80975557d54741305210b"
+appVersion: "e8deccaf0e083482e1783e01c3fa2067f69a9d4c"

--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # 1.0.0
 version: "0.0.106"
 
-appVersion: "e8deccaf0e083482e1783e01c3fa2067f69a9d4c"
+appVersion: "996604c0c5dd5a517fb3ddb096776c834a195250"

--- a/charts/primary-site/templates/deployments/_inbox-container.tpl
+++ b/charts/primary-site/templates/deployments/_inbox-container.tpl
@@ -134,6 +134,9 @@ template:
             value: "{{ .Values.inboxListener.deployment.metrics.subsystem }}"
           - name: PRIMARY_SITE_VERSION
             value: "{{ .Chart.Version }}"
+          ## Not `| default true`, which would flip an explicit false back to true.
+          - name: MERGE_FOXGLOVE_MCAP_METADATA
+            value: {{ dig "mergeFoxgloveMcapMetadata" true .Values.inboxListener.deployment | quote }}
           {{- range $item := .Values.inboxListener.deployment.env }}
           - name: {{ $item.name }}
             value: {{ $item.value | quote}}

--- a/charts/primary-site/templates/deployments/indexer.yaml
+++ b/charts/primary-site/templates/deployments/indexer.yaml
@@ -123,6 +123,9 @@ spec:
               value: "{{ .Values.indexer.deployment.metrics.subsystem }}"
             - name: PRIMARY_SITE_VERSION
               value: "{{ .Chart.Version }}"
+            ## Not `| default true`, which would flip an explicit false back to true.
+            - name: MERGE_FOXGLOVE_MCAP_METADATA
+              value: {{ dig "mergeFoxgloveMcapMetadata" true .Values.indexer.deployment | quote }}
             {{- if .Values.globals.proxy.enabled }}
             - name: HTTP_PROXY
               value: {{ .Values.globals.proxy.httpProxy }}

--- a/charts/primary-site/templates/deployments/query-server.yaml
+++ b/charts/primary-site/templates/deployments/query-server.yaml
@@ -158,6 +158,47 @@ spec:
             {{- end }}
             - name: TOPIC_EXEC_BUFFERED_OBJECT_LIMIT
               value: {{ $values.deployment.topicExec.bufferedObjectLimit | quote }}
+            {{- if $values.deployment.enableBetaStreamExecutor }}
+            {{- $streamExecutor := $values.deployment.streamExecutor }}
+            - name: ENABLE_NEW_STREAM_EXECUTOR
+              value: "true"
+            {{- if $streamExecutor.partitionCount }}
+            - name: STREAM_EXECUTOR_PARTITION_COUNT
+              value: {{ int64 $streamExecutor.partitionCount | quote }}
+            {{- else }}
+            ## Default the partition count to the CPU limit rounded up to whole cores.
+            - name: STREAM_EXECUTOR_PARTITION_COUNT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: query-service
+                  resource: limits.cpu
+                  divisor: "1"
+            {{- end }}
+            {{- if $streamExecutor.partitionBatchBytes }}
+            - name: STREAM_EXECUTOR_PARTITION_BATCH_BYTES
+              value: {{ int64 $streamExecutor.partitionBatchBytes | quote }}
+            {{- end }}
+            {{- if $streamExecutor.chunkGroupBytes }}
+            - name: STREAM_EXECUTOR_GROUP_BYTES
+              value: {{ int64 $streamExecutor.chunkGroupBytes | quote }}
+            {{- end }}
+            {{- if $streamExecutor.coalesceGapBytes }}
+            - name: STREAM_EXECUTOR_COALESCE_GAP_BYTES
+              value: {{ int64 $streamExecutor.coalesceGapBytes | quote }}
+            {{- end }}
+            {{- if $streamExecutor.summaryFetchConcurrency }}
+            - name: STREAM_EXECUTOR_SUMMARY_FETCH_CONCURRENCY
+              value: {{ int64 $streamExecutor.summaryFetchConcurrency | quote }}
+            {{- end }}
+            {{- if $streamExecutor.bufferedChildLimit }}
+            - name: STREAM_EXECUTOR_BUFFERED_CHILD_LIMIT
+              value: {{ int64 $streamExecutor.bufferedChildLimit | quote }}
+            {{- end }}
+            {{- if $streamExecutor.lookbackConcurrency }}
+            - name: STREAM_EXECUTOR_LOOKBACK_CONCURRENCY
+              value: {{ int64 $streamExecutor.lookbackConcurrency | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $item := $values.deployment.env }}
             - name: {{ $item.name }}
               value: {{ $item.value | quote}}

--- a/charts/primary-site/values.schema.json
+++ b/charts/primary-site/values.schema.json
@@ -21,6 +21,59 @@
         "bucketName",
         "storageProvider"
       ]
+    },
+    "streamExecutorLever": {
+      "description": "A positive integer, or empty to fall through to the service default.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "string",
+          "pattern": "^[0-9]*$"
+        }
+      ]
+    },
+    "queryServiceValues": {
+      "type": "object",
+      "properties": {
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "enableBetaStreamExecutor": {
+              "type": "boolean"
+            },
+            "streamExecutor": {
+              "type": "object",
+              "properties": {
+                "partitionCount": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "partitionBatchBytes": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "chunkGroupBytes": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "coalesceGapBytes": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "summaryFetchConcurrency": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "bufferedChildLimit": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                },
+                "lookbackConcurrency": {
+                  "$ref": "#/definitions/streamExecutorLever"
+                }
+              },
+              "additionalProperties": false
+            }
+          }
+        }
+      }
     }
   },
   "type": "object",
@@ -51,6 +104,12 @@
       "requiredProperties": [
         "foxgloveApiUrl"
       ]
+    },
+    "queryService": {
+      "$ref": "#/definitions/queryServiceValues"
+    },
+    "streamService": {
+      "$ref": "#/definitions/queryServiceValues"
     }
   },
   "requiredProperties": [

--- a/charts/primary-site/values.schema.json
+++ b/charts/primary-site/values.schema.json
@@ -105,6 +105,19 @@
         "foxgloveApiUrl"
       ]
     },
+    "indexer": {
+      "type": "object",
+      "properties": {
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "mergeFoxgloveMcapMetadata": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "queryService": {
       "$ref": "#/definitions/queryServiceValues"
     },

--- a/charts/primary-site/values.schema.json
+++ b/charts/primary-site/values.schema.json
@@ -35,6 +35,19 @@
         }
       ]
     },
+    "mcapMetadataValues": {
+      "type": "object",
+      "properties": {
+        "deployment": {
+          "type": "object",
+          "properties": {
+            "mergeFoxgloveMcapMetadata": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
     "queryServiceValues": {
       "type": "object",
       "properties": {
@@ -106,17 +119,10 @@
       ]
     },
     "indexer": {
-      "type": "object",
-      "properties": {
-        "deployment": {
-          "type": "object",
-          "properties": {
-            "mergeFoxgloveMcapMetadata": {
-              "type": "boolean"
-            }
-          }
-        }
-      }
+      "$ref": "#/definitions/mcapMetadataValues"
+    },
+    "inboxListener": {
+      "$ref": "#/definitions/mcapMetadataValues"
     },
     "queryService": {
       "$ref": "#/definitions/queryServiceValues"

--- a/charts/primary-site/values.schema.json
+++ b/charts/primary-site/values.schema.json
@@ -17,7 +17,7 @@
           ]
         }
       },
-      "requiredProperties": [
+      "required": [
         "bucketName",
         "storageProvider"
       ]
@@ -101,7 +101,7 @@
           "$ref": "#/definitions/objectStore"
         }
       },
-      "requiredProperties": [
+      "required": [
         "foxgloveApiUrl"
       ]
     },
@@ -112,7 +112,7 @@
       "$ref": "#/definitions/queryServiceValues"
     }
   },
-  "requiredProperties": [
+  "required": [
     "globals"
   ]
 }

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -111,11 +111,11 @@ inboxListener:
       # exceeded. If the limit is exceeded, local disk or lake storage is used instead of memory.
       # - name: SCRATCH_BUFFER_CAPACITY_BYTES
       #   value: "1073741824"
-      # MERGE_FOXGLOVE_MCAP_METADATA: when reading recording context from MCAP metadata,
-      # merge every "foxglove" metadata record in the file, with later records overriding
-      # earlier keys (default: true). Set to false to use only the last record.
-      # - name: MERGE_FOXGLOVE_MCAP_METADATA
-      #   value: "false"
+    ## When resolving a recording's context from MCAP metadata, merge every "foxglove"
+    ## metadata record in the file, with later records overriding earlier keys and an empty
+    ## string value unsetting a key. Set to false to use only the last "foxglove" record,
+    ## which is how the inbox listener behaved before primary site 0.0.106.
+    mergeFoxgloveMcapMetadata: true
     localScratch:
       # If your primary site is expected to process unindexed MCAP or ROS 1 BAG files, consider
       # configuring your inbox listener deployment with local scratch storage. We recommend

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -180,16 +180,16 @@ indexer:
     metrics:
       namespace: ""
       subsystem: ""
+    ## When resolving a recording's context from MCAP metadata, merge every "foxglove"
+    ## metadata record in the file, with later records overriding earlier keys and an empty
+    ## string value unsetting a key. Set to false to use only the last "foxglove" record,
+    ## which is how the indexer behaved before primary site 0.0.106.
+    mergeFoxgloveMcapMetadata: true
     env:
       []
       # MAX_CONCURRENCY: adjust the number of concurrent workers for indexing recordings.
       # - name: MAX_CONCURRENCY
       #   value: 4
-      # MERGE_FOXGLOVE_MCAP_METADATA: when reading recording context from MCAP metadata,
-      # merge every "foxglove" metadata record in the file, with later records overriding
-      # earlier keys (default: true). Set to false to use only the last record.
-      # - name: MERGE_FOXGLOVE_MCAP_METADATA
-      #   value: "false"
     serviceAccount:
       enabled: false
       annotations: {}

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -111,6 +111,11 @@ inboxListener:
       # exceeded. If the limit is exceeded, local disk or lake storage is used instead of memory.
       # - name: SCRATCH_BUFFER_CAPACITY_BYTES
       #   value: "1073741824"
+      # MERGE_FOXGLOVE_MCAP_METADATA: when reading recording context from MCAP metadata,
+      # merge every "foxglove" metadata record in the file, with later records overriding
+      # earlier keys (default: true). Set to false to use only the last record.
+      # - name: MERGE_FOXGLOVE_MCAP_METADATA
+      #   value: "false"
     localScratch:
       # If your primary site is expected to process unindexed MCAP or ROS 1 BAG files, consider
       # configuring your inbox listener deployment with local scratch storage. We recommend
@@ -180,6 +185,11 @@ indexer:
       # MAX_CONCURRENCY: adjust the number of concurrent workers for indexing recordings.
       # - name: MAX_CONCURRENCY
       #   value: 4
+      # MERGE_FOXGLOVE_MCAP_METADATA: when reading recording context from MCAP metadata,
+      # merge every "foxglove" metadata record in the file, with later records overriding
+      # earlier keys (default: true). Set to false to use only the last record.
+      # - name: MERGE_FOXGLOVE_MCAP_METADATA
+      #   value: "false"
     serviceAccount:
       enabled: false
       annotations: {}
@@ -212,6 +222,38 @@ queryService:
       partitionCount: ""
       ## Max concurrent object reads buffered per partition.
       bufferedObjectLimit: 8
+    ## Beta: read streamed messages with the new multi-threaded stream executor.
+    ## It reads a stream's MCAP chunks across several parallel partitions, which can
+    ## substantially improve streaming throughput on multi-core query service pods.
+    ## Disabled by default; the values under `streamExecutor` only apply when enabled.
+    enableBetaStreamExecutor: false
+    streamExecutor:
+      ## Number of partitions the stream's merge is fanned out across, each on its own
+      ## task. Defaults to the CPU limit rounded up to whole cores when left empty.
+      ## Set to 1 to run the merge inline on a single task.
+      partitionCount: ""
+      ## Payload bytes batched from a partition before handing off to the root merge.
+      ## Leave empty for the service default (8388608, 8 MiB).
+      partitionBatchBytes: ""
+      ## Target byte span of a coalesced group of MCAP chunks. Neighbouring chunks are
+      ## fetched in one read up to this size, so raising it trades memory for fewer,
+      ## larger reads. A single chunk larger than this forms its own group.
+      ## Leave empty for the service default (4194304, 4 MiB).
+      chunkGroupBytes: ""
+      ## Chunks separated by at most this many bytes are coalesced into one group,
+      ## reading the gap between them rather than issuing a second request.
+      ## Leave empty for the service default (1048576, 1 MiB).
+      coalesceGapBytes: ""
+      ## Number of MCAP summary sections fetched concurrently. Files whose summary has
+      ## not landed yet hold up message release, so a wide window helps wide streams.
+      ## Leave empty for the service default (256).
+      summaryFetchConcurrency: ""
+      ## Max chunk groups buffered per partition merge.
+      ## Leave empty for the service default (8).
+      bufferedChildLimit: ""
+      ## Number of files whose chunk lookback passes run at one time.
+      ## Leave empty for the service default (256).
+      lookbackConcurrency: ""
     env: []
     serviceAccount:
       enabled: false

--- a/charts/primary-site/values.yaml
+++ b/charts/primary-site/values.yaml
@@ -238,7 +238,7 @@ queryService:
       ## Target byte span of a coalesced group of MCAP chunks. Neighbouring chunks are
       ## fetched in one read up to this size, so raising it trades memory for fewer,
       ## larger reads. A single chunk larger than this forms its own group.
-      ## Leave empty for the service default (4194304, 4 MiB).
+      ## Leave empty for the service default (33554432, 32 MiB).
       chunkGroupBytes: ""
       ## Chunks separated by at most this many bytes are coalesced into one group,
       ## reading the gap between them rather than issuing a second request.


### PR DESCRIPTION
### Changelog

- Merge all `"foxglove"` MCAP metadata records when resolving recording context, instead of using only the last record
- Add `mergeFoxgloveMcapMetadata` to the indexer and inbox listener to restore the previous last-record-only behaviour
- Add a beta multi-threaded stream executor for message streaming, off by default behind `queryService.deployment.enableBetaStreamExecutor`
- Improve query service error messages when a stream fails mid-response
- Validate stream executor values in `values.schema.json`, and fix a typo that left the schema's existing required-property checks inactive

### Docs

None

### Description

Updates the primary site to include the new stream executor and metadata merging changes. It includes levers in the values yaml to pipe everything through.

I've tested and this all works well deploying to my sandbox.

<details>
<summary>extra context from agent</summary>

- appVersion moves from `38838a2` to `e8deccaf0e083482e1783e01c3fa2067f69a9d4c` (data-platform main).
- Metadata merging is data-platform #3488; the stream executor is #3315 (core, behind `ENABLE_NEW_STREAM_EXECUTOR`), #3309 (chunk group loader), #3366 (lookback), #3311 (partitioning), #3406 (cooperative yielding).
- Env var mapping: `enableBetaStreamExecutor` → `ENABLE_NEW_STREAM_EXECUTOR`, and `streamExecutor.{partitionCount,partitionBatchBytes,chunkGroupBytes,coalesceGapBytes,summaryFetchConcurrency,bufferedChildLimit,lookbackConcurrency}` → `STREAM_EXECUTOR_{PARTITION_COUNT,PARTITION_BATCH_BYTES,GROUP_BYTES,COALESCE_GAP_BYTES,SUMMARY_FETCH_CONCURRENCY,BUFFERED_CHILD_LIMIT,LOOKBACK_CONCURRENCY}`.
- The partition-count block mirrors the existing `topicExec.partitionCount` pattern (explicit value, else `resourceFieldRef` on `limits.cpu`), and matches how data-platform's own chart wires this up for BYOS.
- The two `mergeFoxgloveMcapMetadata` options are emitted through `dig "..." true`, not `| default true` — `default` treats `false` as empty and would have silently flipped an explicit opt-out back on.
- Only one of the indexer / inbox listener is deployed for a given `indexingStrategy`, so a site only ever needs the option matching its strategy. Both are emitted before `deployment.env`, so an existing raw `MERGE_FOXGLOVE_MCAP_METADATA` env entry still wins (verified).
- The other levers emit only when set, rather than being pinned to chart-side defaults, so internal tuning defaults stay owned by the service.
- Numeric levers render through `int64` — `--set` parses bare numbers as float64, which otherwise produced values like `"1.6777216e+07"`.
- The schema's `requiredProperties` keys were a typo for `required`, so nothing in the file was actually being required. Fixed; the newly-live checks (`globals`, `globals.foxgloveApiUrl`, and `bucketName`/`storageProvider` on each object store) are all satisfied by the chart defaults and by both `tests/` configs, which rely on those defaults.
- `additionalProperties: false` is scoped to the `streamExecutor` object only, so a typo'd lever fails loudly; the surrounding objects stay open.
- Verified with `helm lint` and `helm template`: zero `STREAM_EXECUTOR` vars by default; all eight render with the flag on; deep merge through `streamService` (query-optimized layout) preserves the `streamExecutor` defaults when only some keys are overridden.
</details>


