### PR TITLE
remote-data-loader v0.0.10

### DIFF
--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -11,6 +11,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.9"
+version: "0.0.10"
 
-appVersion: "870efc318a2068fb274557b2e47389069e8c5a7d"
+appVersion: "8e7020f31478a5c41d8c4fca98bc751f2a2b9f86"


### PR DESCRIPTION
### Changelog

- `remote-data-loader`'s `/liveness` and `/` health checks no longer produce request/response log lines or CORS headers, matching how `query-server` already handles the same routes — health-check probes were previously logged identically to real traffic, drowning out logs that matter.
- Latched and low-frequency messages published near the start of a recording are now backfilled when seeking, regardless of how far into the recording the seek is — including across file boundaries on multi-file recordings.

### Docs

None

### Description

Bumps the `remote-data-loader` chart to `8e7020f31478a5c41d8c4fca98bc751f2a2b9f86`.

Linear: https://linear.app/foxglove/issue/DB-256/exclude-liveness-from-remote-data-loader-request-logging

<details><summary>extra context</summary>

- Only `Chart.yaml` changed (`version` 0.0.9 → 0.0.10, `appVersion` bumped). No new env vars/config were introduced in this range, so `values.yaml`, `values.schema.json`, and templates are untouched.
- Two user-facing commits in this range, verified against `remote-data-loader`'s actual dependency surface (its `Cargo.toml` only depends on `common`/`query-engine`, and it only imports a specific subset of `query-engine`'s stream-executor modules) rather than assumed from commit titles:
  - `remote-data-loader: exclude /liveness and / from request tracing and CORS (#3578)` — DB-256.
  - `query-server: add lastPerChannelInRange replay policy (DB-145) (#3376)` — directly edits `remote-data-loader`'s own `stream.rs`/`stream_handler.rs`; also, unrecognized replay-policy strings now return a clear 400 instead of this service silently mapping `Unknown` to no backfill.
- The remaining 17 commits touching `rust/common`/`rust/query-engine` in this range were checked individually and confirmed not to affect `remote-data-loader`: unreachable from its code paths (query-server/billing/agent/indexer/embeddings-only, or gated behind a query-server-only env var), or non-behavioral (a lint fix, an Azure field this service always passes as `None`, a test-mock type-signature fixup).
</details>

