### PR TITLE
primary-site: 0.0.107

### DIFF
--- a/charts/primary-site/Chart.yaml
+++ b/charts/primary-site/Chart.yaml
@@ -13,6 +13,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.106"
+version: "0.0.107"
 
-appVersion: "996604c0c5dd5a517fb3ddb096776c834a195250"
+appVersion: "1e53dc4f9f4b45e76b5a8e0abd14b97b37e43a03"


### PR DESCRIPTION
### Changelog

- Add the `lastPerChannelInRange` replay policy to the query service, so a stream request can recover the last message per channel from anywhere in the range the API returns (latched topics on seek)
- Add a `/v1/list-objects` query service endpoint that streams bucket objects and prefixes
- Collect invalid object keys during paginated listing instead of failing the whole listing
- Pass the Azure storage account through `ObjectRef` and keep manifests container-only
- Support ClickHouse-backed streams for message-path-only requests
- Improve observability of Columnstore-backed streams
- Handle a dropped command channel gracefully in the beta stream executor's partition stream

### Docs

None

### Description

Bumps the primary site to a data-platform main that contains the `lastPerChannelInRange` replay policy (data-platform #3376, DB-145 / DB-720). Customer-managed sites are version-gated on this chart release before the app will send the new policy, so this release is what unblocks that gate.

No template or values changes. The policy is selected per stream request and needs no new configuration, and none of the other changes in the range add required env vars for the components this chart deploys.

<details>
<summary>extra context from agent</summary>

- appVersion moves from `996604c0c5` to `1e53dc4f9f4b45e76b5a8e0abd14b97b37e43a03` (data-platform main, 2026-08-04). 37 commits in the range.
- CI is green on `1e53dc4f` and all 24 `build-push` jobs succeeded, so amd64 + arm64 images exist for every component this chart pins (query-server, indexer, inbox-listener, site-controller, garbage-collector).
- The changelog is filtered to the five components primary-site actually deploys. The rest of the range is hosted-only or AWS BYOS only: ClickHouse PrivateLink target changes, production autoscaling, ml/inference model work, recording-post-processor table-optimize ScaledJob and Arrow ZSTD staging, AWS BYOS inference and image-embedding-worker rollout, and the `recording-discovery` crate extraction out of the agent.
- `remote-data-loader` also changed in the range (#3578, liveness and root path excluded from request tracing and CORS), but that ships from its own chart, which is being bumped separately in #188.
- The app-side capability gate `MIN_SITE_VERSION_FOR_IN_RANGE_LOOKBACK` should be set to `0.0.107` once this merges and the chart is released.

</details>
