### PR TITLE
remote-data-loader v0.0.11

### DIFF
--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -11,6 +11,6 @@ type: application
 # 1.0.0-alpha.0
 # 1.0.0-alpha.1
 # 1.0.0
-version: "0.0.10"
+version: "0.0.11"
 
-appVersion: "8e7020f31478a5c41d8c4fca98bc751f2a2b9f86"
+appVersion: "be2317c651c291545a1ec2ca34742b294acd5938"

--- a/charts/remote-data-loader/Chart.yaml
+++ b/charts/remote-data-loader/Chart.yaml
@@ -13,4 +13,4 @@ type: application
 # 1.0.0
 version: "0.0.11"
 
-appVersion: "be2317c651c291545a1ec2ca34742b294acd5938"
+appVersion: "cfcf9b0b04b6840306959865e57e9eb20f4afdb0"


### PR DESCRIPTION
### Changelog

- `remote-data-loader`'s `/` health check returns CORS headers again. 0.0.10 moved `/` and `/liveness` outside the middleware stack to keep probe traffic out of the logs, but the app calls `/` from the browser as a reachability check, so it needs `Access-Control-Allow-Origin`. `/liveness` stays quiet.
- A data backend's `x-foxglove-error-message` header is now passed through on streamed data failures, not just manifest failures, so users see the backend's message instead of a generic error.
- Replay lookback now returns every message at a channel's latest pre-seek timestamp, instead of an arbitrary one when several share that timestamp.

### Docs

foxglove/app#17682

### Description

Bumps the `remote-data-loader` chart to `cfcf9b0b04b6840306959865e57e9eb20f4afdb0`.

<details><summary>extra context from agent</summary>

- Only `Chart.yaml` changed (`version` 0.0.10 → 0.0.11, `appVersion` bumped). No new env vars or config in this range, so `values.yaml`, `values.schema.json`, and templates are untouched.
- 41 commits in the range. Three touch `rust/remote-data-loader` itself and are the three changelog entries above: `remote-data-loader: run / through the middleware stack (#3657)`, `Pass through x-foxglove-error-message from streamed data responses (#3644)`, and `Yield every lookback message at a channel's latest timestamp (#3599)` (which edits this service's own `streamed_lookback_source.rs` / `filtered_event_stream.rs`).
- The other commits touching `rust/query-engine` / `rust/common` are ClickHouse- and query-server-specific paths (column-store planning, CH shadow streams, preflight timeouts, fingerprinting, index-in-place metadata). I checked their diff surface rather than auditing each end-to-end for reachability from this service.
- The `/` change reverses part of DB-256 (#3578), which shipped in 0.0.10 — that PR moved both health routes outside the stack, and the CORS loss on `/` was collateral.
- Per #3644, the error-message pass-through covers streamed sources only; static file sources go through `object_store`, which drops response headers in its retry layer.
- CI on `cfcf9b0b0` was still in progress when this was updated; the image tag has to exist before this merges.
</details>
